### PR TITLE
Adding PR and To-DO GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/todo.yml
+++ b/.github/ISSUE_TEMPLATE/todo.yml
@@ -1,0 +1,17 @@
+name: To-Do
+description: Small task for the blog/site
+title: "TODO: "
+labels: ["todo"]
+body:
+  - type: textarea
+    id: task
+    attributes:
+      label: What to do
+      description: One clear sentence.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Context, links, URLs, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Summary
+Briefly describe the change.
+
+## What changed
+- [ ] Content only
+- [ ] Config/CI
+- [ ] Bug fix
+- [ ] New feature
+
+## Why
+Why this change is needed.
+
+## How tested
+- [ ] Built locally (`bundle exec jekyll build`)
+- [ ] Proofer subset passed (`bundle exec ruby scripts/proof_subset.rb _site/index.html`)
+
+## Risks / Deploy notes
+Any gotchas or follow-ups.
+
+## Related
+Closes #<issue>, refs #<issue>


### PR DESCRIPTION
## What
- Add issue form: `.github/ISSUE_TEMPLATE/todo.yml` (simple To-Do with `todo` label).
- Add PR template: `.github/pull_request_template.md` (scope checklist + testing checklist, proofer note).

## Why
- Standardize tiny maintenance tasks via GitHub Issues.
- Encourage consistent PR context and testing notes.

## Impact
- Meta-only change—no site content, build, or deploy logic affected.

## Testing
- Changes developed on `chore/todo-template`.
- Issue form will appear on **New issue** after merge.
- PR template applies to **future PRs** automatically.

## Follow-ups
- Ensure the `todo` label exists in the repo.
- (Optional) Document the workflow in `CONTRIBUTING.md`.