### PR TITLE
Disqus: fallback + container (refs #27)

### DIFF
--- a/_includes/comments-providers/disqus.html
+++ b/_includes/comments-providers/disqus.html
@@ -1,15 +1,47 @@
 {% if site.comments.disqus.shortname %}
-  <script>
-    var disqus_config = function () {
-      this.page.url = "{{ page.url | absolute_url }}";  /* Replace PAGE_URL with your page's canonical URL variable */
-      this.page.identifier = "{{ page.id }}"; /* Replace PAGE_IDENTIFIER with your page's unique identifier variable */
+<div id="disqus_thread"></div>
+
+<script>
+  var disqus_config = function () {
+    this.page.url = "{{ page.url | absolute_url }}";
+    this.page.identifier = "{{ page.id }}";
+  };
+
+  (function () {
+    var d = document, s = d.createElement('script');
+    s.src = 'https://{{ site.comments.disqus.shortname }}.disqus.com/embed.js';
+    s.setAttribute('data-timestamp', +new Date());
+    s.async = true;
+    s.onerror = function () {
+      var fb = document.getElementById('disqus-fallback');
+      if (fb) fb.hidden = false;
     };
-    (function() { /* DON'T EDIT BELOW THIS LINE */
-      var d = document, s = d.createElement('script');
-      s.src = 'https://{{ site.comments.disqus.shortname }}.disqus.com/embed.js';
-      s.setAttribute('data-timestamp', +new Date());
-      (d.head || d.body).appendChild(s);
-    })();
-  </script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    (d.head || d.body).appendChild(s);
+  })();
+</script>
+
+<p id="disqus-fallback" hidden>
+  Comments load from Disqus and might be blocked by a privacy tool.
+  You can
+  <a href="https://{{ site.comments.disqus.shortname }}.disqus.com/?url={{ page.url | absolute_url }}"
+     rel="nofollow noopener" target="_blank">
+    open the discussion on Disqus
+  </a>
+  or permit <code>{{ site.comments.disqus.shortname }}.disqus.com</code> for this site.
+</p>
+
+<script>
+  // Reveal fallback if Disqus never initializes (blocked or network failure)
+  setTimeout(function () {
+    if (!window.DISQUS) {
+      var fb = document.getElementById('disqus-fallback');
+      if (fb) fb.hidden = false;
+    }
+  }, 2500);
+</script>
+
+<noscript>
+  Please enable JavaScript to view the
+  <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a>
+</noscript>
 {% endif %}


### PR DESCRIPTION
Adds #disqus_thread and a soft fallback when embed is blocked.