### PR TITLE
fix: clarify noindex strategy and document canonical tag approach

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -71,6 +71,8 @@ const structuredData = {
     <link rel="apple-touch-icon" href={`${import.meta.env.BASE_URL}apple-touch-icon.png`} />
     <link rel="manifest" href={`${import.meta.env.BASE_URL}site.webmanifest.json`} />
 
+    {/* Canonical link: tells search engines and tools where the "true" content lives.
+        Can point to this page or to an external canonical URL via the canonicalURL prop. */}
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 
@@ -148,8 +150,12 @@ const structuredData = {
       )
     }
 
-    {/* Deindex staging builds explicitly via deploy env flag */}
-    {isStaging && <meta name="robots" content="noindex,nofollow" />}
+    {/* Staging is deindexed to prevent preview builds from appearing in search results.
+        Production is indexed normally (default behavior). Canonical link tag above can
+        optionally point to external content if needed. */}
+    {isStaging && (
+      <meta name="robots" content="noindex,nofollow" />
+    )}
 
     <ClientRouter />
 


### PR DESCRIPTION
## Summary
- Staging is deindexed to prevent preview builds from appearing in search results
- Production uses default search engine indexing behavior
- Canonical link tag documented for optionally pointing to external content
- robots.txt.ts already aligned: staging blocks crawlers, production allows them

## Test plan
- [x] Docker build passes
- [x] Layout renders correctly with conditional robots meta tag
- [x] robots.txt.ts already correctly aligned with this approach
- [x] Comments document the indexing strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)