### PR TITLE
fix(presentations): use canonical home link

### DIFF
--- a/docs/PRESENTATION_HTML_GUIDE.md
+++ b/docs/PRESENTATION_HTML_GUIDE.md
@@ -110,7 +110,7 @@ const htmlFile = linkWithBase(`/presentations/${id}.html`);
 
 **Link to Home**: Use relative path in presentation HTML:
 ```html
-<a href="../../index.html" class="home-link">← Home</a>
+<a href="../" class="home-link">← Home</a>
 ```
 
 ## Content Types That Work

--- a/docs/operations/code-change-process.md
+++ b/docs/operations/code-change-process.md
@@ -122,6 +122,7 @@ Before submitting for review:
 - [ ] No redundancy (e.g., explicit defaults that achieve nothing)
 - [ ] Comments explain intent and reference related files if applicable
 - [ ] Commit message accurately describes all changes
+- [ ] Tests updated or added for the new behavior (especially when links/routes change)
 
 ### Documentation Sync
 

--- a/public/presentations/2019-Feb-SLG.html
+++ b/public/presentations/2019-Feb-SLG.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/2019-drupalcon-drupal-8-multisite.html
+++ b/public/presentations/2019-drupalcon-drupal-8-multisite.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/bundle-test.html
+++ b/public/presentations/bundle-test.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/code-presentation.html
+++ b/public/presentations/code-presentation.html
@@ -269,7 +269,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/drupal-intro.html
+++ b/public/presentations/drupal-intro.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/drupal-multisite-on-a-dime.html
+++ b/public/presentations/drupal-multisite-on-a-dime.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/tts-profile-mgmt.html
+++ b/public/presentations/tts-profile-mgmt.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/public/presentations/wohd.html
+++ b/public/presentations/wohd.html
@@ -240,7 +240,7 @@
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/scripts/build-presentations.js
+++ b/scripts/build-presentations.js
@@ -352,7 +352,7 @@ function generateHtml(title, slides) {
     </style>
 </head>
 <body>
-    <a href="../index.html" class="home-link">← Home</a>
+    <a href="../" class="home-link">← Home</a>
     <div class="progress-bar" id="progressBar"></div>
 
     <div class="presentation-container" id="container" data-pagefind-body>

--- a/tests/link-validation.spec.ts
+++ b/tests/link-validation.spec.ts
@@ -161,4 +161,17 @@ test.describe('Link Validation', () => {
 		const response = await page.goto(resolveUrl(presHref!), { waitUntil: 'networkidle' });
 		expect(response?.status()).toBe(200);
 	});
+
+	test('presentation home link points to canonical root', async ({ page }) => {
+		await page.goto(resolveUrl('/presentations/wohd.html'), { waitUntil: 'networkidle' });
+
+		const homeLink = page.locator('a.home-link');
+		await expect(homeLink).toBeVisible();
+
+		const href = await homeLink.getAttribute('href');
+		expect(href, 'Expected Home link to use a relative root path').toBe('../');
+
+		await homeLink.click();
+		await expect(page).toHaveURL(resolveUrl('/'));
+	});
 });


### PR DESCRIPTION
Summary:
- Update presentation Home link to use ../ instead of ../index.html (canonical root).
- Regenerate presentation HTML outputs to match.
- Update the presentation HTML guide and generator template.
- Add Playwright coverage for presentation Home link behavior.
- Update the code change process to require test updates for behavior changes.

Files touched:
- scripts/build-presentations.js
- public/presentations/*.html
- docs/PRESENTATION_HTML_GUIDE.md
- tests/link-validation.spec.ts
- docs/operations/code-change-process.md
