### PR TITLE
fix: update htmltest download URL to match new release asset naming

### DIFF
--- a/.github/workflows/linkwatch.yml
+++ b/.github/workflows/linkwatch.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           HTMLTEST_VERSION: "0.17.0"
         run: |
-          curl -sL -o htmltest.tar.gz "https://github.com/wjdp/htmltest/releases/download/v${HTMLTEST_VERSION}/htmltest_Linux_x86_64.tar.gz"
+          curl -sL -o htmltest.tar.gz "https://github.com/wjdp/htmltest/releases/download/v${HTMLTEST_VERSION}/htmltest_${HTMLTEST_VERSION}_linux_amd64.tar.gz"
           tar -xzf htmltest.tar.gz
           sudo mv htmltest /usr/local/bin/
           htmltest --version


### PR DESCRIPTION
## Summary
- Fixes failing linkwatch build due to incorrect htmltest download URL
- Asset filename changed from `htmltest_Linux_x86_64.tar.gz` to `htmltest_${VERSION}_linux_amd64.tar.gz` in the v0.17.0 release

## Test plan
- [ ] Verify linkwatch workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)