### PR TITLE
Fix link checker: accept HTTP 999 as withheld + reporting clarity

### DIFF
--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -226,13 +226,14 @@ This script:
 
 #### If Browser Verification Succeeds ✅
 
-The URL works for real users but fails automated checks. Add domain to `.htmltest.yml` only if:
-- The browser check succeeded (HTTP 200 or redirect)
-- The htmltest failure was NOT a 403 or 999 response (403s and 999s are automatically withheld by the script)
+The URL is "not broken." The script distinguishes two outcomes:
+
+- **Reachable** — browser returned HTTP 2xx (or a redirect to a 2xx). The URL works for real users; htmltest's failure is bot detection. The script suggests adding to `IgnoreURLs`.
+- **Withheld** — browser returned 403 or 999 (LinkedIn-style anti-bot). The resource exists but is gated against automated clients (Chromium too). The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.
 
 ```yaml
 IgnoreURLs:
-  - "example.com"  # Works in browsers, blocks bots (non-403/999 failure)
+  - "example.com"  # Reachable in browser, blocks htmltest (non-403/999 failure)
 ```
 
 Do NOT add domains for permanent failures (404s, TLS certificate errors, timeout issues).
@@ -303,7 +304,7 @@ npm run test:links
 ## Ignore List Guidelines
 
 Add domains to `IgnoreURLs` when:
-- ✅ URL works in real browsers (verified with browser)
+- ✅ URL is **reachable** in real browsers (HTTP 2xx — distinct from "withheld")
 - ✅ URL fails automated checks **BUT has explicit status code** (404, 429, 503, etc.)
 - ✅ Site is legitimate and trustworthy
 - ✅ Content is still valuable to readers

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -180,7 +180,7 @@ IgnoreURLs:
   # ... etc
 ```
 
-**Note**: 403 responses and connection/TLS errors are automatically withheld (not suggested for IgnoreURLs).
+**Note**: 403 responses, 999 responses (LinkedIn-style anti-bot), and connection/TLS errors are automatically withheld (not suggested for IgnoreURLs).
 
 ## Handling Link Check Failures
 
@@ -228,11 +228,11 @@ This script:
 
 The URL works for real users but fails automated checks. Add domain to `.htmltest.yml` only if:
 - The browser check succeeded (HTTP 200 or redirect)
-- The htmltest failure was NOT a 403 response (403s are automatically withheld by the script)
+- The htmltest failure was NOT a 403 or 999 response (403s and 999s are automatically withheld by the script)
 
 ```yaml
 IgnoreURLs:
-  - "example.com"  # Works in browsers, blocks bots (non-403 failure)
+  - "example.com"  # Works in browsers, blocks bots (non-403/999 failure)
 ```
 
 Do NOT add domains for permanent failures (404s, TLS certificate errors, timeout issues).
@@ -307,14 +307,15 @@ Add domains to `IgnoreURLs` when:
 - ✅ URL fails automated checks **BUT has explicit status code** (404, 429, 503, etc.)
 - ✅ Site is legitimate and trustworthy
 - ✅ Content is still valuable to readers
-- ⚠️  **Never add** 403 responses (withheld by policy), connection errors, or URLs that also fail in browser
+- ⚠️  **Never add** 403 or 999 responses (withheld by policy), connection errors, or URLs that also fail in browser
 
 Do NOT add to ignore list when:
 - ❌ URL fails browser verification (genuinely broken - timeout, TLS error, connection refused, etc.)
 - ❌ Content has moved to new URL
 - ❌ Site is permanently offline
-- ⚠️  **Policy Exclusions**: 
+- ⚠️  **Policy Exclusions**:
   - 403 responses: withheld by policy (not added even if browser works)
+  - 999 responses: withheld by policy (LinkedIn-style anti-bot; not added even if browser works)
   - Connection/TLS errors (no status code): not suggested (real issues to investigate)
   - 404 in both htmltest and browser: genuinely broken (don't ignore)
 
@@ -325,6 +326,7 @@ Sites may report different errors to bots vs real browsers:
 | Pattern | htmltest Reports | Browser Returns | Action |
 |---------|------------------|-----------------|--------|
 | **Aggressive bot detection** | 403 | 200 OK | Withheld by policy (403s never added) |
+| **LinkedIn-style anti-bot** | 999 | 999 (still blocked headless) | Withheld by policy (999s never added) |
 | **Softer bot detection** | 404 | 200 OK | May add to ignore list (script suggests) |
 | **Rate limiting** | 429 | 200 OK | May add to ignore list |
 | **Genuinely broken** | 404 | 404 | Do NOT add (link needs fixing) |

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -261,8 +261,13 @@ try {
     const result = await verifyUrl(page, url);
     results.push(result);
 
-    if (result.success) {
-      console.log(`  ✅ ${result.status} - Works in browser`);
+    if (result.reachable) {
+      console.log(`  ✅ ${result.status} - Reachable in browser`);
+      if (result.redirected) {
+        console.log(`  → Redirects to: ${result.finalUrl}`);
+      }
+    } else if (result.withheld) {
+      console.log(`  ℹ️  ${result.status} - Withheld (browser also gated; resource exists)`);
       if (result.redirected) {
         console.log(`  → Redirects to: ${result.finalUrl}`);
       }
@@ -285,16 +290,20 @@ console.log('FINAL REPORT');
 console.log('━'.repeat(60));
 
 const working = results.filter(r => r.success);
+const reachableResults = results.filter(r => r.reachable);
+const withheldResults = results.filter(r => r.withheld);
 const broken = results.filter(r => !r.success);
 
 console.log(`\n📊 Summary:`);
 if (isManualMode) {
   console.log(`   URLs checked: ${failedUrls.length}`);
-  console.log(`   ✅ Working: ${working.length}`);
+  console.log(`   ✅ Reachable: ${reachableResults.length}`);
+  console.log(`   ℹ️  Withheld (gated): ${withheldResults.length}`);
   console.log(`   ❌ Broken: ${broken.length}`);
 } else {
   console.log(`   Unique URLs from htmltest: ${failedUrls.length}`);
-  console.log(`   ✅ Working in real browser: ${working.length}`);
+  console.log(`   ✅ Reachable in real browser: ${reachableResults.length}`);
+  console.log(`   ℹ️  Withheld (browser also gated): ${withheldResults.length}`);
   console.log(`   ❌ Actually broken: ${broken.length}`);
 }
 
@@ -321,7 +330,7 @@ if (!isManualMode) {
 if (working.length > 0 && !isManualMode) {
 
   if (ignoreCandidates.length > 0) {
-    console.log('\n✅ URLs that work in browser (add to .htmltest.yml IgnoreURLs):');
+    console.log('\n✅ URLs reachable in browser (add to .htmltest.yml IgnoreURLs):');
     console.log('━'.repeat(60));
 
     const domains = [...new Set(ignoreCandidates.map(r => {
@@ -346,11 +355,18 @@ if (working.length > 0 && !isManualMode) {
     });
   }
 
+  const formatWithheld = (r) => {
+    const browserState = r.reachable
+      ? `browser: ${r.status} reachable`
+      : `browser: ${r.status} also gated`;
+    return `  - ${r.url}  (${browserState})`;
+  };
+
   if (withheld403s.length > 0) {
-    console.log('\nℹ️  URLs that work in browser but returned 403 in htmltest (not adding to IgnoreURLs):');
+    console.log('\nℹ️  htmltest reported 403 — withheld by policy (not added to IgnoreURLs):');
     console.log('━'.repeat(60));
     withheld403s.forEach(r => {
-      console.log(`  - ${r.url}`);
+      console.log(formatWithheld(r));
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);
       }
@@ -358,10 +374,10 @@ if (working.length > 0 && !isManualMode) {
   }
 
   if (withheld999s.length > 0) {
-    console.log('\nℹ️  URLs that work in browser but returned 999 in htmltest (not adding to IgnoreURLs):');
+    console.log('\nℹ️  htmltest reported 999 — withheld by policy (not added to IgnoreURLs):');
     console.log('━'.repeat(60));
     withheld999s.forEach(r => {
-      console.log(`  - ${r.url}`);
+      console.log(formatWithheld(r));
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);
       }
@@ -369,10 +385,11 @@ if (working.length > 0 && !isManualMode) {
   }
 
   if (connectionErrors.length > 0) {
-    console.log('\n⚠️  URLs that work in browser but had connection/TLS errors in htmltest (investigate):');
+    console.log('\n⚠️  htmltest had connection/TLS errors but browser succeeded (investigate):');
     console.log('━'.repeat(60));
     connectionErrors.forEach(r => {
-      console.log(`  - ${r.url}`);
+      const browserState = r.reachable ? 'reachable' : 'withheld';
+      console.log(`  - ${r.url}  (browser: ${browserState})`);
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);
       }
@@ -400,19 +417,20 @@ if (broken.length > 0) {
 console.log('\n' + '━'.repeat(60));
 
 // Exit with appropriate code
-// Note: 403s that work in browser are withheld from ignore list by policy, but still represent
-// successful links (not broken), so they don't trigger exit(1). Only genuinely broken links fail.
+// Note: 403/999 responses are withheld from the ignore list by policy but still represent
+// non-broken links (resource exists, just gated against automation), so they don't trigger
+// exit(1). Only genuinely broken links fail.
 if (broken.length > 0) {
   console.log(`\n⚠️  ${broken.length} link(s) need manual attention\n`);
   process.exit(1);
 }
 
 if (isManualMode && working.length > 0) {
-  console.log(`\n✅ All provided URLs are accessible\n`);
+  console.log(`\n✅ All provided URLs are accounted for (reachable or withheld)\n`);
 } else if (ignoreCandidates.length > 0) {
-  console.log(`\n✅ All failed links work in browser - update ignore list\n`);
+  console.log(`\n✅ All failed links reachable in browser - update ignore list\n`);
 } else if (working.length > 0) {
-  console.log(`\n✅ All failed links work in browser - no ignore list updates suggested\n`);
+  console.log(`\n✅ All failed links accounted for (reachable or withheld) - no ignore list updates suggested\n`);
 }
 
 process.exit(0);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -302,17 +302,19 @@ if (isManualMode) {
 // Manual mode doesn't have htmltest status, so skip this categorization
 let ignoreCandidates = [];
 let withheld403s = [];
+let withheld999s = [];
 let connectionErrors = [];
 
 if (!isManualMode) {
   // Compute candidates in outer scope for use throughout reporting and exit logic
   // Include: URLs with explicit HTTP status (404, 429, 503, etc.) suggesting bot-blocking
-  // Exclude: 403s (withheld by policy), null/undefined (TLS/connection errors)
+  // Exclude: 403s and 999s (withheld by policy), null/undefined (TLS/connection errors)
   ignoreCandidates = working.filter(r => {
     const status = statusByUrl.get(r.url);
-    return status !== 403 && status !== null && status !== undefined;
+    return status !== 403 && status !== 999 && status !== null && status !== undefined;
   });
   withheld403s = working.filter(r => statusByUrl.get(r.url) === 403);
+  withheld999s = working.filter(r => statusByUrl.get(r.url) === 999);
   connectionErrors = working.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
 }
 
@@ -348,6 +350,17 @@ if (working.length > 0 && !isManualMode) {
     console.log('\nℹ️  URLs that work in browser but returned 403 in htmltest (not adding to IgnoreURLs):');
     console.log('━'.repeat(60));
     withheld403s.forEach(r => {
+      console.log(`  - ${r.url}`);
+      if (r.redirected) {
+        console.log(`    → Redirects to: ${r.finalUrl}`);
+      }
+    });
+  }
+
+  if (withheld999s.length > 0) {
+    console.log('\nℹ️  URLs that work in browser but returned 999 in htmltest (not adding to IgnoreURLs):');
+    console.log('━'.repeat(60));
+    withheld999s.forEach(r => {
       console.log(`  - ${r.url}`);
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -311,9 +311,16 @@ if (isManualMode) {
 
 // In automated mode, categorize non-broken URLs by their htmltest status for detailed reporting
 // Manual mode doesn't have htmltest status, so skip this categorization
+//
+// Naming convention: arrays prefixed with `htmltest` are keyed on the htmltest
+// status code; arrays prefixed with `browser` are keyed on the browser result.
+// Mixing the two created a reporting gap (Copilot, PR #105 round 4) where a
+// browser-withheld URL whose htmltest status was non-policy (e.g., 404) would
+// be counted in the summary but appear in no detail section.
 let ignoreCandidates = [];
-let withheld403s = [];
-let withheld999s = [];
+let htmltest403s = [];
+let htmltest999s = [];
+let browserWithheldOther = [];
 let connectionErrors = [];
 
 if (!isManualMode) {
@@ -329,9 +336,16 @@ if (!isManualMode) {
     const status = statusByUrl.get(r.url);
     return status !== 403 && status !== 999 && status !== null && status !== undefined;
   });
-  withheld403s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 403);
-  withheld999s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 999);
+  htmltest403s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 403);
+  htmltest999s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 999);
   connectionErrors = notBrokenResults.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
+  // Catch browser-withheld URLs whose htmltest status doesn't match any policy
+  // bucket above, so every URL counted in the withheld summary appears in some
+  // detail section.
+  browserWithheldOther = withheldResults.filter(r => {
+    const status = statusByUrl.get(r.url);
+    return status !== 403 && status !== 999 && status !== null && status !== undefined;
+  });
 }
 
 if (notBrokenResults.length > 0 && !isManualMode) {
@@ -369,10 +383,10 @@ if (notBrokenResults.length > 0 && !isManualMode) {
     return `  - ${r.url}  (${browserState})`;
   };
 
-  if (withheld403s.length > 0) {
+  if (htmltest403s.length > 0) {
     console.log('\nℹ️  htmltest reported 403 — withheld by policy (not added to IgnoreURLs):');
     console.log('━'.repeat(60));
-    withheld403s.forEach(r => {
+    htmltest403s.forEach(r => {
       console.log(formatWithheld(r));
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);
@@ -380,11 +394,23 @@ if (notBrokenResults.length > 0 && !isManualMode) {
     });
   }
 
-  if (withheld999s.length > 0) {
+  if (htmltest999s.length > 0) {
     console.log('\nℹ️  htmltest reported 999 — withheld by policy (not added to IgnoreURLs):');
     console.log('━'.repeat(60));
-    withheld999s.forEach(r => {
+    htmltest999s.forEach(r => {
       console.log(formatWithheld(r));
+      if (r.redirected) {
+        console.log(`    → Redirects to: ${r.finalUrl}`);
+      }
+    });
+  }
+
+  if (browserWithheldOther.length > 0) {
+    console.log('\nℹ️  Browser was gated (403/999) but htmltest reported a different status (not added to IgnoreURLs):');
+    console.log('━'.repeat(60));
+    browserWithheldOther.forEach(r => {
+      const htmltestStatus = statusByUrl.get(r.url);
+      console.log(`  - ${r.url}  (htmltest: ${htmltestStatus}, browser: ${r.status} gated)`);
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);
       }
@@ -392,10 +418,10 @@ if (notBrokenResults.length > 0 && !isManualMode) {
   }
 
   if (connectionErrors.length > 0) {
-    console.log('\n⚠️  htmltest had connection/TLS errors but browser reached the URL (investigate):');
+    console.log('\n⚠️  htmltest had connection/TLS errors but browser got a response (investigate):');
     console.log('━'.repeat(60));
     connectionErrors.forEach(r => {
-      const browserState = r.reachable ? 'reachable' : 'withheld';
+      const browserState = r.reachable ? `${r.status} reachable` : `${r.status} gated`;
       console.log(`  - ${r.url}  (browser: ${browserState})`);
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -316,9 +316,14 @@ let connectionErrors = [];
 
 if (!isManualMode) {
   // Compute candidates in outer scope for use throughout reporting and exit logic
-  // Include: URLs with explicit HTTP status (404, 429, 503, etc.) suggesting bot-blocking
-  // Exclude: 403s and 999s (withheld by policy), null/undefined (TLS/connection errors)
-  ignoreCandidates = working.filter(r => {
+  // Include: URLs the browser actually reached (HTTP 2xx) AND whose htmltest
+  //   failure had an explicit non-policy status (404, 429, 503, etc.)
+  // Exclude:
+  //   - browser-withheld URLs (403/999) — gated against automation, not safe
+  //     to auto-suggest as a permanent ignore even if htmltest's status differs
+  //   - htmltest 403/999 — withheld by policy regardless of browser outcome
+  //   - htmltest null/undefined — TLS/connection errors, kept visible for investigation
+  ignoreCandidates = reachableResults.filter(r => {
     const status = statusByUrl.get(r.url);
     return status !== 403 && status !== 999 && status !== null && status !== undefined;
   });

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -289,7 +289,9 @@ console.log('\n━'.repeat(60));
 console.log('FINAL REPORT');
 console.log('━'.repeat(60));
 
-const working = results.filter(r => r.success);
+// notBrokenResults includes both reachable (2xx) and withheld (403/999) URLs;
+// kept as a single set for sectioning logic that doesn't care which flavor.
+const notBrokenResults = results.filter(r => r.success);
 const reachableResults = results.filter(r => r.reachable);
 const withheldResults = results.filter(r => r.withheld);
 const broken = results.filter(r => !r.success);
@@ -307,7 +309,7 @@ if (isManualMode) {
   console.log(`   ❌ Actually broken: ${broken.length}`);
 }
 
-// In automated mode, categorize working URLs by their htmltest status for detailed reporting
+// In automated mode, categorize non-broken URLs by their htmltest status for detailed reporting
 // Manual mode doesn't have htmltest status, so skip this categorization
 let ignoreCandidates = [];
 let withheld403s = [];
@@ -327,12 +329,12 @@ if (!isManualMode) {
     const status = statusByUrl.get(r.url);
     return status !== 403 && status !== 999 && status !== null && status !== undefined;
   });
-  withheld403s = working.filter(r => statusByUrl.get(r.url) === 403);
-  withheld999s = working.filter(r => statusByUrl.get(r.url) === 999);
-  connectionErrors = working.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
+  withheld403s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 403);
+  withheld999s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 999);
+  connectionErrors = notBrokenResults.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
 }
 
-if (working.length > 0 && !isManualMode) {
+if (notBrokenResults.length > 0 && !isManualMode) {
 
   if (ignoreCandidates.length > 0) {
     console.log('\n✅ URLs reachable in browser (add to .htmltest.yml IgnoreURLs):');
@@ -390,7 +392,7 @@ if (working.length > 0 && !isManualMode) {
   }
 
   if (connectionErrors.length > 0) {
-    console.log('\n⚠️  htmltest had connection/TLS errors but browser succeeded (investigate):');
+    console.log('\n⚠️  htmltest had connection/TLS errors but browser reached the URL (investigate):');
     console.log('━'.repeat(60));
     connectionErrors.forEach(r => {
       const browserState = r.reachable ? 'reachable' : 'withheld';
@@ -430,11 +432,11 @@ if (broken.length > 0) {
   process.exit(1);
 }
 
-if (isManualMode && working.length > 0) {
+if (isManualMode && notBrokenResults.length > 0) {
   console.log(`\n✅ All provided URLs are accounted for (reachable or withheld)\n`);
 } else if (ignoreCandidates.length > 0) {
   console.log(`\n✅ All failed links reachable in browser - update ignore list\n`);
-} else if (working.length > 0) {
+} else if (notBrokenResults.length > 0) {
   console.log(`\n✅ All failed links accounted for (reachable or withheld) - no ignore list updates suggested\n`);
 }
 

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -19,23 +19,30 @@ export async function verifyUrl(page, url) {
 
     const status = response ? response.status() : 'NO_RESPONSE';
 
-    // 403 (access-controlled) and 999 (LinkedIn-style anti-bot) mean the
-    // resource exists but is gated against automated clients. Treat both
-    // as success so headless verification doesn't false-positive them as
-    // broken when their htmltest equivalent already flagged the same gate.
-    const isSuccess = response && (response.ok() || status === 403 || status === 999);
+    // Two distinct flavors of "not broken":
+    //   reachable: 2xx — the page actually loaded for the browser
+    //   withheld: 403/999 — the resource exists but gates automated
+    //     clients. Same semantic class as a 403 from htmltest.
+    // success keeps the broad "not broken" meaning so callers that only
+    // care about pass/fail don't have to inspect both flags.
+    const reachable = !!(response && response.ok());
+    const withheld = !!(response && (status === 403 || status === 999));
 
     return {
       url,
       status,
       finalUrl: page.url(),
       redirected: page.url() !== url,
-      success: !!isSuccess
+      reachable,
+      withheld,
+      success: reachable || withheld
     };
   } catch (error) {
     return {
       url,
       error: error.message,
+      reachable: false,
+      withheld: false,
       success: false
     };
   }

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -19,9 +19,11 @@ export async function verifyUrl(page, url) {
 
     const status = response ? response.status() : 'NO_RESPONSE';
 
-    // 403 means resource exists (access-controlled), not broken
-    // Accept 2xx (OK) and 403 (Forbidden) as success
-    const isSuccess = response && (response.ok() || status === 403);
+    // 403 (access-controlled) and 999 (LinkedIn-style anti-bot) mean the
+    // resource exists but is gated against automated clients. Treat both
+    // as success so headless verification doesn't false-positive them as
+    // broken when their htmltest equivalent already flagged the same gate.
+    const isSuccess = response && (response.ok() || status === 403 || status === 999);
 
     return {
       url,


### PR DESCRIPTION
## Summary
- Treat HTTP 999 (LinkedIn anti-bot) as withheld, not broken — same policy as 403
- Split `success` into explicit `reachable` (2xx) + `withheld` (403/999) flags in verify-url
- Refactor reporting: rename `working` → `notBrokenResults`, distinguish htmltest-keyed (`htmltest403s`/`htmltest999s`) from browser-keyed (`browserWithheldOther`) buckets
- Close gap where browser-withheld URLs with non-policy htmltest status counted in summary but appeared in no detail section
- Reword connection-errors header from "browser reached the URL" → "browser got a response" (since `connectionErrors` includes withheld too)

Resolves Issue #102 (CI link check failing on 119 LinkedIn 999s).

## Test plan
- [x] `npm run build` passes
- [x] `npm run check:links` passes locally
- [x] Pre-push docker build test passes
- [ ] CI link check passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)