### PR TITLE
fix(check-links): harden 503 maintenance heuristic and fix two-tier integrity

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -13,5 +13,3 @@ IgnoreURLs:
   - "about.gitlab.com"  # Connection reset in htmltest, works in browser
   - "claude.ai"  # Connection reset in htmltest, works in browser
   - "drupal.org/u/grasmash"  # Intermittent timeouts, works in real browsers
-  - "linkedin.com"  # Returns inconsistent status codes (404/429/999) per request; bot-gated, works in browsers
-  - "ubuntu.com"  # ERR_CONNECTION_RESET in CI; works in real browsers

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -13,3 +13,5 @@ IgnoreURLs:
   - "about.gitlab.com"  # Connection reset in htmltest, works in browser
   - "claude.ai"  # Connection reset in htmltest, works in browser
   - "drupal.org/u/grasmash"  # Intermittent timeouts, works in real browsers
+  - "linkedin.com"  # Returns inconsistent status codes (404/429/999) per request; bot-gated, works in browsers
+  - "ubuntu.com"  # ERR_CONNECTION_RESET in CI; works in real browsers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,6 @@ Confirmed: proceeding with [task] despite [blocker].
 ## Code Changes
 - Batch related edits into single operations
 - Make minimal edits to accomplish goal
-- Commit after each working change
 - Use descriptive commit messages
 
 ## Verification Protocol
@@ -432,7 +431,7 @@ When instructions appear to conflict:
 **Approval gates are hard stops, not tradeoffs.**
 - Do not let autonomy, bias-to-action, or end-to-end completion override an approval requirement.
 - Re-check authorization immediately before each gated action.
-- Missing approval means do not execute the action.
+- Missing approval means do not execute the action. (Exception: steps implied by an explicitly requested workflow are pre-approved — see workflow exception above.)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ When I say:
 - **Hard gate for sensitive actions:** use deny-by-default for `commit`, `push`, branch-changing git actions, and destructive actions.
 - **Exact approval required per action:** "fix" ≠ "commit" ≠ "push". Do not infer one from another.
 - **Fail closed:** if explicit approval for the exact action is missing or ambiguous, STOP.
+- **Workflow exception:** when the user requests a workflow that inherently includes commit/push steps (e.g., "fix and update branches", "apply the fix and push"), those steps are pre-approved by the workflow request. The gate blocks uninstructed ad-hoc actions, not steps implied by an explicitly requested workflow.
 
 **Never guess what I want. Never add unrequested complexity. Never skip requested discussion.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ git checkout develop && git pull origin develop
 ### Making Changes
 1. Ensure you're on `develop` branch and synced
 2. Make your changes
-3. Commit with descriptive messages
+3. Commit with descriptive messages **only if explicitly asked to commit**
 4. Push to origin: `git push origin develop` **only if explicitly asked to push** (on failure, see Blocker Resolution Protocol)
 5. Create PR: `develop` → `staging`
 6. After staging approval, create PR: `staging` → `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,10 @@ When I say:
 **Before taking ANY action (editing files, committing, pushing):**
 - Check: Did I explicitly ask you to do this action?
 - If I asked to "review" or "discuss" → STOP. Report findings. Wait.
-- If I asked to "fix" or "implement" → Proceed with action.
+- If I asked to "fix" or "implement" → Proceed with edits only.
+- **Hard gate for sensitive actions:** use deny-by-default for `commit`, `push`, branch-changing git actions, and destructive actions.
+- **Exact approval required per action:** "fix" ≠ "commit" ≠ "push". Do not infer one from another.
+- **Fail closed:** if explicit approval for the exact action is missing or ambiguous, STOP.
 
 **Never guess what I want. Never add unrequested complexity. Never skip requested discussion.**
 
@@ -166,7 +169,7 @@ git checkout develop && git pull origin develop
 1. Ensure you're on `develop` branch and synced
 2. Make your changes
 3. Commit with descriptive messages
-4. Push to origin: `git push origin develop` (on failure, see Blocker Resolution Protocol)
+4. Push to origin: `git push origin develop` **only if explicitly asked to push** (on failure, see Blocker Resolution Protocol)
 5. Create PR: `develop` → `staging`
 6. After staging approval, create PR: `staging` → `main`
 
@@ -418,6 +421,11 @@ When instructions appear to conflict:
 3. **Source hierarchy:** CLAUDE.md overrides Memory (Memory may be outdated)
 4. **User authority:** User explicit instructions override all written rules
 5. **Scope sensitivity:** Some rules are scope-dependent (e.g., quality gates for code vs docs)
+
+**Approval gates are hard stops, not tradeoffs.**
+- Do not let autonomy, bias-to-action, or end-to-end completion override an approval requirement.
+- Re-check authorization immediately before each gated action.
+- Missing approval means do not execute the action.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,11 @@ git push origin develop
 - Example: Comments on PR (staging→main) → fix on `staging` branch
 - If fixes were made on wrong branch, cherry-pick to correct branch (on failure, see Blocker Resolution Protocol)
 
+### No Out-of-Scope Commits
+- Do **not** commit changes unrelated to the current task to any branch mid-session
+- Instructions like "update X" mean make the change in the file; they do not imply commit unless explicitly requested
+- Approval gates apply per-change: a request to edit a file is not approval to commit it
+
 ## Blocker Resolution Protocol
 
 **DEFAULT: When operations fail (exit code != 0 or explicit error):**
@@ -406,6 +411,7 @@ When addressing review comments:
 - Ask clarifying questions before exploration
 - Summarize findings in <100 words when possible
 - Skip unnecessary engagement phrases ("You're right!", "Perfect!", "Good catch!")
+- No anthropomorphizing qualifiers ("Honestly…", "To be frank…", "I should mention…") — just state facts directly
 - Be direct and concise — just state what you're doing or what needs to be done (but ONLY if I asked you to do it)
 - **Exception:** Blocker reporting requires verbose detail (state, options, consequences) per Blocker Resolution Protocol
 
@@ -419,7 +425,7 @@ When instructions appear to conflict:
    - Build scripts, CI/CD workflows
    - Test files and test infrastructure
 3. **Source hierarchy:** CLAUDE.md overrides Memory (Memory may be outdated)
-4. **User authority:** User explicit instructions override all written rules
+4. **User authority:** User explicit instructions override general written rules — approval gates are satisfied by explicit per-action user instruction (which is the override mechanism, not a bypass)
 5. **Scope sensitivity:** Some rules are scope-dependent (e.g., quality gates for code vs docs)
 
 **Approval gates are hard stops, not tradeoffs.**

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -226,7 +226,7 @@ This script:
 
 #### If Browser Verification Succeeds ✅
 
-The URL is "not broken." The script distinguishes two outcomes:
+The URL is "not broken." The script distinguishes three outcomes:
 
 - **Reachable** — browser returned HTTP 2xx (or a redirect to a 2xx). The URL works for real users; htmltest's failure is bot detection. The script suggests adding to `IgnoreURLs`.
 - **Withheld** — browser returned 403, 429 (rate-limited/bot-gated), or 999 (LinkedIn-style anti-bot). The resource exists but is gated against automated clients. The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -319,7 +319,7 @@ Do NOT add to ignore list when:
   - 403 responses: withheld by policy (not added even if browser works)
   - 429 responses: withheld (rate-limited/bot-gated; not added even if browser is also gated)
   - 999 responses: withheld by policy (LinkedIn-style anti-bot; not added even if browser works)
-  - 503 maintenance pages: temporary (not added; `Retry-After` header or maintenance-mode page content detected)
+  - 503 maintenance pages: temporary (not added; maintenance-mode page content required; `Retry-After` header used as corroborating evidence only)
   - Connection/TLS errors (no status code): not suggested (real issues to investigate)
   - 404 in both htmltest and browser: genuinely broken (don't ignore)
 

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -229,7 +229,7 @@ This script:
 The URL is "not broken." The script distinguishes three outcomes:
 
 - **Reachable** — browser returned HTTP 2xx (or a redirect to a 2xx). The URL works for real users; htmltest's failure is bot detection. The script suggests adding to `IgnoreURLs`.
-- **Withheld** — browser returned 403, 429 (rate-limited/bot-gated), or 999 (LinkedIn-style anti-bot). The resource exists but is gated against automated clients. The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.
+- **Withheld** — browser returned 403, 429 (rate-limited/bot-gated), or 999 (LinkedIn-style anti-bot). For 403/999 the resource exists but is gated against automated clients; for 429 the server is rate-limiting and existence of the resource is unconfirmed. The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.
 - **Temporary** — browser returned 503 with maintenance signals (a `Retry-After` header, or page content containing "scheduled maintenance", "under maintenance", or "maintenance mode"). The site is undergoing maintenance; the link is not broken. The script does NOT suggest adding these to `IgnoreURLs`.
 
 ```yaml

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -180,7 +180,7 @@ IgnoreURLs:
   # ... etc
 ```
 
-**Note**: 403 responses, 429 responses (rate-limited/bot-gated), 999 responses (LinkedIn-style anti-bot), and connection/TLS errors are automatically withheld (not suggested for IgnoreURLs).
+**Note**: 403 responses and 999 responses (LinkedIn-style anti-bot) are automatically withheld from IgnoreURLs suggestions. 429 responses where the browser is also gated are similarly withheld. Connection/TLS errors are kept visible for investigation — they are not withheld and will fail the run if the browser confirms the URL is unreachable.
 
 ## Handling Link Check Failures
 

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -228,9 +228,9 @@ This script:
 
 The URL is "not broken." The script distinguishes three outcomes:
 
-- **Reachable** — browser returned HTTP 2xx (or a redirect to a 2xx). The URL works for real users; htmltest's failure is bot detection. The script suggests adding to `IgnoreURLs`.
+- **Reachable** — browser returned HTTP 2xx (or a redirect to a 2xx). The URL is reachable in a real browser even though htmltest flagged it. The script suggests adding to `IgnoreURLs`.
 - **Withheld** — browser returned 403, 429 (rate-limited/bot-gated), or 999 (LinkedIn-style anti-bot). For 403/999 the resource exists but is gated against automated clients; for 429 the server is rate-limiting and existence of the resource is unconfirmed. The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.
-- **Temporary** — browser returned 503 with maintenance signals (a `Retry-After` header, or page content containing "scheduled maintenance", "under maintenance", or "maintenance mode"). The site is undergoing maintenance; the link is not broken. The script does NOT suggest adding these to `IgnoreURLs`.
+- **Temporary** — browser returned 503 with explicit maintenance-mode page content ("scheduled maintenance", "under maintenance", or "maintenance mode"). A `Retry-After` header is treated as corroborating evidence but is not sufficient alone. The site is undergoing maintenance; the link is not broken. The script does NOT suggest adding these to `IgnoreURLs`.
 
 ```yaml
 IgnoreURLs:
@@ -343,7 +343,6 @@ Sites may report different errors to bots vs real browsers:
 | Domain | Reason |
 |--------|--------|
 | `nytimes.com` | Aggressive bot detection (rate limiting) |
-| `linkedin.com` | Returns 999 status to block scrapers |
 | `onedrive.live.com` | Bot-blocking (works fine in real browser) |
 | `microsoft.com/store` | Bot detection |
 | Government sites (`.gov`) | Often block automated tools for security |

--- a/docs/link-checking.md
+++ b/docs/link-checking.md
@@ -180,7 +180,7 @@ IgnoreURLs:
   # ... etc
 ```
 
-**Note**: 403 responses, 999 responses (LinkedIn-style anti-bot), and connection/TLS errors are automatically withheld (not suggested for IgnoreURLs).
+**Note**: 403 responses, 429 responses (rate-limited/bot-gated), 999 responses (LinkedIn-style anti-bot), and connection/TLS errors are automatically withheld (not suggested for IgnoreURLs).
 
 ## Handling Link Check Failures
 
@@ -229,7 +229,8 @@ This script:
 The URL is "not broken." The script distinguishes two outcomes:
 
 - **Reachable** — browser returned HTTP 2xx (or a redirect to a 2xx). The URL works for real users; htmltest's failure is bot detection. The script suggests adding to `IgnoreURLs`.
-- **Withheld** — browser returned 403 or 999 (LinkedIn-style anti-bot). The resource exists but is gated against automated clients (Chromium too). The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.
+- **Withheld** — browser returned 403, 429 (rate-limited/bot-gated), or 999 (LinkedIn-style anti-bot). The resource exists but is gated against automated clients. The script does NOT suggest adding these to `IgnoreURLs` — leave them in content; the policy treats them as non-broken without permanently skipping them.
+- **Temporary** — browser returned 503 with maintenance signals (a `Retry-After` header, or page content containing "scheduled maintenance", "under maintenance", or "maintenance mode"). The site is undergoing maintenance; the link is not broken. The script does NOT suggest adding these to `IgnoreURLs`.
 
 ```yaml
 IgnoreURLs:
@@ -305,7 +306,7 @@ npm run test:links
 
 Add domains to `IgnoreURLs` when:
 - ✅ URL is **reachable** in real browsers (HTTP 2xx — distinct from "withheld")
-- ✅ URL fails automated checks **BUT has explicit status code** (404, 429, 503, etc.)
+- ✅ URL fails automated checks **BUT has explicit non-policy status code** (e.g., 404)
 - ✅ Site is legitimate and trustworthy
 - ✅ Content is still valuable to readers
 - ⚠️  **Never add** 403 or 999 responses (withheld by policy), connection errors, or URLs that also fail in browser
@@ -316,7 +317,9 @@ Do NOT add to ignore list when:
 - ❌ Site is permanently offline
 - ⚠️  **Policy Exclusions**:
   - 403 responses: withheld by policy (not added even if browser works)
+  - 429 responses: withheld (rate-limited/bot-gated; not added even if browser is also gated)
   - 999 responses: withheld by policy (LinkedIn-style anti-bot; not added even if browser works)
+  - 503 maintenance pages: temporary (not added; `Retry-After` header or maintenance-mode page content detected)
   - Connection/TLS errors (no status code): not suggested (real issues to investigate)
   - 404 in both htmltest and browser: genuinely broken (don't ignore)
 
@@ -329,9 +332,11 @@ Sites may report different errors to bots vs real browsers:
 | **Aggressive bot detection** | 403 | 200 OK | Withheld by policy (403s never added) |
 | **LinkedIn-style anti-bot** | 999 | 999 (still blocked headless) | Withheld by policy (999s never added) |
 | **Softer bot detection** | 404 | 200 OK | May add to ignore list (script suggests) |
-| **Rate limiting** | 429 | 200 OK | May add to ignore list |
+| **Rate limiting — browser clear** | 429 | 200 OK | May add to ignore list (script suggests) |
+| **Rate limiting — both gated** | 429 | 429 gated | Withheld (rate-limited; not added to IgnoreURLs) |
 | **Genuinely broken** | 404 | 404 | Do NOT add (link needs fixing) |
 | **Proxy issues** | 503 | 200 OK | May add to ignore list |
+| **Maintenance page** | 503 | 503 maintenance | Temporary (not added; re-check after maintenance) |
 
 **Key Rule**: Only add to ignore list if the URL **works in browser verification**. If browser also fails, the link is genuinely broken and should be fixed, not ignored.
 

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -378,10 +378,11 @@ if (!isManualMode) {
   connectionErrors = notBrokenResults.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
   // Catch browser-withheld URLs whose htmltest status doesn't match any policy
   // bucket above, so every URL counted in the withheld summary appears in some
-  // detail section.
+  // detail section. Exclude 429 — those are already covered by htmltest429s,
+  // and including them here would produce duplicate detail output.
   browserWithheldOther = withheldResults.filter(r => {
     const status = statusByUrl.get(r.url);
-    return status !== 403 && status !== 999 && status !== null && status !== undefined;
+    return status !== 403 && status !== 429 && status !== 999 && status !== null && status !== undefined;
   });
   browserTemporaryOther = temporaryResults.filter(r => {
     const status = statusByUrl.get(r.url);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -267,7 +267,10 @@ try {
         console.log(`  → Redirects to: ${result.finalUrl}`);
       }
     } else if (result.withheld) {
-      console.log(`  ℹ️  ${result.status} - Withheld (browser also gated; resource exists)`);
+      const withheldMsg = result.status === 429
+        ? 'Rate-limited / bot-gated'
+        : 'Withheld (browser also gated; resource exists)';
+      console.log(`  ℹ️  ${result.status} - ${withheldMsg}`);
       if (result.redirected) {
         console.log(`  → Redirects to: ${result.finalUrl}`);
       }

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -318,6 +318,13 @@ const htmltest429s = !isManualMode
   : [];
 const trulyBroken = broken;
 
+// Summary counts segmented by browser status so labels match actual bucket contents.
+// withheld403_999: browser returned 403 or 999 (policy blocks, resource exists)
+// withheld429:     browser returned 429 (rate-limited/bot-gated)
+// Both are non-broken; kept separate because they have different operator meanings.
+const withheld403_999Count = withheldResults.filter(r => r.status === 403 || r.status === 999).length;
+const withheld429Count = withheldResults.filter(r => r.status === 429).length;
+
 console.log(`\n📊 Summary:`);
 if (isManualMode) {
   console.log(`   URLs checked: ${failedUrls.length}`);
@@ -328,11 +335,11 @@ if (isManualMode) {
 } else {
   console.log(`   Unique URLs from htmltest: ${failedUrls.length}`);
   console.log(`   ✅ Reachable in real browser: ${reachableResults.length}`);
-  console.log(`   ℹ️  Withheld (browser gated: 403/999): ${withheldResults.length - htmltest429s.length}`);
-  console.log(`   ⏸️  Temporarily unavailable (503 maintenance): ${temporaryResults.length}`);
-  if (htmltest429s.length > 0) {
-    console.log(`   🚫 Rate-limited / bot-gated (429): ${htmltest429s.length}`);
+  console.log(`   ℹ️  Withheld (browser gated 403/999): ${withheld403_999Count}`);
+  if (withheld429Count > 0) {
+    console.log(`   🚫 Rate-limited / bot-gated (browser 429): ${withheld429Count}`);
   }
+  console.log(`   ⏸️  Temporarily unavailable (503 maintenance): ${temporaryResults.length}`);
   console.log(`   ❌ Actually broken: ${trulyBroken.length}`);
 }
 
@@ -545,8 +552,6 @@ if (isManualMode && notBrokenResults.length > 0) {
   console.log(`\n✅ All failed links reachable in browser - update ignore list\n`);
 } else if (notBrokenResults.length > 0) {
   console.log(`\n✅ All failed links accounted for (reachable, withheld, or temporary) - no ignore list updates suggested\n`);
-} else if (!isManualMode && htmltest429s.length > 0) {
-  console.log(`\n✅ No genuinely broken links — all failures are rate-limited (429 bot-gated)\n`);
 }
 
 process.exit(0);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -456,7 +456,7 @@ if (notBrokenResults.length > 0 && !isManualMode) {
   }
 
   if (browserWithheldOther.length > 0) {
-    console.log('\nℹ️  Browser was gated (403/429/999) but htmltest reported a different status (not added to IgnoreURLs):');
+    console.log('\nℹ️  Browser was gated (403/429/999) — htmltest status outside dedicated policy buckets (not added to IgnoreURLs):');
     console.log('━'.repeat(60));
     browserWithheldOther.forEach(r => {
       const htmltestStatus = statusByUrl.get(r.url);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -296,17 +296,31 @@ const reachableResults = results.filter(r => r.reachable);
 const withheldResults = results.filter(r => r.withheld);
 const broken = results.filter(r => !r.success);
 
+// HTTP 429 = rate-limited/bot-gated; resource exists but automation is throttled.
+// Like 403/999, these are not genuinely broken links. Separate from trulyBroken so
+// they don't cause false-positive exit(1) while remaining visible in the report.
+// (Only meaningful in automated mode where htmltest status codes are available.)
+const htmltest429s = !isManualMode
+  ? broken.filter(r => statusByUrl.get(r.url) === 429)
+  : [];
+const trulyBroken = !isManualMode
+  ? broken.filter(r => statusByUrl.get(r.url) !== 429)
+  : broken;
+
 console.log(`\n📊 Summary:`);
 if (isManualMode) {
   console.log(`   URLs checked: ${failedUrls.length}`);
   console.log(`   ✅ Reachable: ${reachableResults.length}`);
   console.log(`   ℹ️  Withheld (gated): ${withheldResults.length}`);
-  console.log(`   ❌ Broken: ${broken.length}`);
+  console.log(`   ❌ Broken: ${trulyBroken.length}`);
 } else {
   console.log(`   Unique URLs from htmltest: ${failedUrls.length}`);
   console.log(`   ✅ Reachable in real browser: ${reachableResults.length}`);
   console.log(`   ℹ️  Withheld (browser also gated): ${withheldResults.length}`);
-  console.log(`   ❌ Actually broken: ${broken.length}`);
+  if (htmltest429s.length > 0) {
+    console.log(`   🚫 Rate-limited / bot-gated (429): ${htmltest429s.length}`);
+  }
+  console.log(`   ❌ Actually broken: ${trulyBroken.length}`);
 }
 
 // In automated mode, categorize non-broken URLs by their htmltest status for detailed reporting
@@ -430,10 +444,23 @@ if (notBrokenResults.length > 0 && !isManualMode) {
   }
 }
 
-if (broken.length > 0) {
+// 429-gated URLs are reported outside the notBrokenResults guard because
+// they appear in `broken` (browser also failed), not in `notBrokenResults`.
+if (!isManualMode && htmltest429s.length > 0) {
+  console.log('\nℹ️  htmltest reported 429 — rate-limited / bot-gated (not added to IgnoreURLs):');
+  console.log('━'.repeat(60));
+  htmltest429s.forEach(r => {
+    console.log(`  - ${r.url}`);
+    if (r.error) {
+      console.log(`    → ${r.error}`);
+    }
+  });
+}
+
+if (trulyBroken.length > 0) {
   console.log('\n❌ URLs that are actually broken (need manual fixes):');
   console.log('━'.repeat(60));
-  broken.forEach(r => {
+  trulyBroken.forEach(r => {
     console.log(`  - ${r.url}`);
     if (r.error) {
       console.log(`    Reason: ${r.error}`);
@@ -450,11 +477,11 @@ if (broken.length > 0) {
 console.log('\n' + '━'.repeat(60));
 
 // Exit with appropriate code
-// Note: 403/999 responses are withheld from the ignore list by policy but still represent
+// Note: 403/999/429 responses are withheld from the ignore list by policy but still represent
 // non-broken links (resource exists, just gated against automation), so they don't trigger
 // exit(1). Only genuinely broken links fail.
-if (broken.length > 0) {
-  console.log(`\n⚠️  ${broken.length} link(s) need manual attention\n`);
+if (trulyBroken.length > 0) {
+  console.log(`\n⚠️  ${trulyBroken.length} link(s) need manual attention\n`);
   process.exit(1);
 }
 
@@ -464,6 +491,8 @@ if (isManualMode && notBrokenResults.length > 0) {
   console.log(`\n✅ All failed links reachable in browser - update ignore list\n`);
 } else if (notBrokenResults.length > 0) {
   console.log(`\n✅ All failed links accounted for (reachable or withheld) - no ignore list updates suggested\n`);
+} else if (!isManualMode && htmltest429s.length > 0) {
+  console.log(`\n✅ No genuinely broken links — all failures are rate-limited (429 bot-gated)\n`);
 }
 
 process.exit(0);

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -271,6 +271,14 @@ try {
       if (result.redirected) {
         console.log(`  → Redirects to: ${result.finalUrl}`);
       }
+    } else if (result.temporary) {
+      console.log(`  ⏸️  ${result.status} - Temporarily unavailable (maintenance page)`);
+      if (result.retryAfter) {
+        console.log(`  → Retry-After: ${result.retryAfter}`);
+      }
+      if (result.redirected) {
+        console.log(`  → Redirects to: ${result.finalUrl}`);
+      }
     } else {
       console.log(`  ❌ Failed in browser`);
       if (result.error) {
@@ -289,15 +297,17 @@ console.log('\n━'.repeat(60));
 console.log('FINAL REPORT');
 console.log('━'.repeat(60));
 
-// notBrokenResults includes both reachable (2xx) and withheld (403/999) URLs;
+// notBrokenResults includes reachable (2xx), withheld (403/429/999), and
+// temporary maintenance (503 with strong maintenance signals) URLs.
 // kept as a single set for sectioning logic that doesn't care which flavor.
 const notBrokenResults = results.filter(r => r.success);
 const reachableResults = results.filter(r => r.reachable);
 const withheldResults = results.filter(r => r.withheld);
+const temporaryResults = results.filter(r => r.temporary);
 const broken = results.filter(r => !r.success);
 
 // HTTP 429 = rate-limited/bot-gated; resource exists but automation is throttled.
-// Like 403/999, these are not genuinely broken links. Separate from trulyBroken so
+// Like 403/429/999, these are not genuinely broken links. Separate from trulyBroken so
 // they don't cause false-positive exit(1) while remaining visible in the report.
 // (Only meaningful in automated mode where htmltest status codes are available.)
 const htmltest429s = !isManualMode
@@ -312,11 +322,13 @@ if (isManualMode) {
   console.log(`   URLs checked: ${failedUrls.length}`);
   console.log(`   ✅ Reachable: ${reachableResults.length}`);
   console.log(`   ℹ️  Withheld (gated): ${withheldResults.length}`);
+  console.log(`   ⏸️  Temporarily unavailable (maintenance): ${temporaryResults.length}`);
   console.log(`   ❌ Broken: ${trulyBroken.length}`);
 } else {
   console.log(`   Unique URLs from htmltest: ${failedUrls.length}`);
   console.log(`   ✅ Reachable in real browser: ${reachableResults.length}`);
   console.log(`   ℹ️  Withheld (browser also gated): ${withheldResults.length}`);
+  console.log(`   ⏸️  Temporarily unavailable (503 maintenance): ${temporaryResults.length}`);
   if (htmltest429s.length > 0) {
     console.log(`   🚫 Rate-limited / bot-gated (429): ${htmltest429s.length}`);
   }
@@ -334,7 +346,9 @@ if (isManualMode) {
 let ignoreCandidates = [];
 let htmltest403s = [];
 let htmltest999s = [];
+let htmltest503Temporaries = [];
 let browserWithheldOther = [];
+let browserTemporaryOther = [];
 let connectionErrors = [];
 
 if (!isManualMode) {
@@ -342,7 +356,7 @@ if (!isManualMode) {
   // Include: URLs the browser actually reached (HTTP 2xx) AND whose htmltest
   //   failure had an explicit non-policy status (404, 429, 503, etc.)
   // Exclude:
-  //   - browser-withheld URLs (403/999) — gated against automation, not safe
+  //   - browser-withheld URLs (403/429/999) — gated against automation, not safe
   //     to auto-suggest as a permanent ignore even if htmltest's status differs
   //   - htmltest 403/999 — withheld by policy regardless of browser outcome
   //   - htmltest null/undefined — TLS/connection errors, kept visible for investigation
@@ -352,6 +366,7 @@ if (!isManualMode) {
   });
   htmltest403s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 403);
   htmltest999s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 999);
+  htmltest503Temporaries = temporaryResults.filter(r => statusByUrl.get(r.url) === 503);
   connectionErrors = notBrokenResults.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
   // Catch browser-withheld URLs whose htmltest status doesn't match any policy
   // bucket above, so every URL counted in the withheld summary appears in some
@@ -359,6 +374,10 @@ if (!isManualMode) {
   browserWithheldOther = withheldResults.filter(r => {
     const status = statusByUrl.get(r.url);
     return status !== 403 && status !== 999 && status !== null && status !== undefined;
+  });
+  browserTemporaryOther = temporaryResults.filter(r => {
+    const status = statusByUrl.get(r.url);
+    return status !== 503 && status !== null && status !== undefined;
   });
 }
 
@@ -419,8 +438,22 @@ if (notBrokenResults.length > 0 && !isManualMode) {
     });
   }
 
+  if (htmltest503Temporaries.length > 0) {
+    console.log('\nℹ️  htmltest reported 503 — temporary maintenance page (not added to IgnoreURLs):');
+    console.log('━'.repeat(60));
+    htmltest503Temporaries.forEach(r => {
+      console.log(`  - ${r.url}  (browser: ${r.status} maintenance page)`);
+      if (r.retryAfter) {
+        console.log(`    → Retry-After: ${r.retryAfter}`);
+      }
+      if (r.redirected) {
+        console.log(`    → Redirects to: ${r.finalUrl}`);
+      }
+    });
+  }
+
   if (browserWithheldOther.length > 0) {
-    console.log('\nℹ️  Browser was gated (403/999) but htmltest reported a different status (not added to IgnoreURLs):');
+    console.log('\nℹ️  Browser was gated (403/429/999) but htmltest reported a different status (not added to IgnoreURLs):');
     console.log('━'.repeat(60));
     browserWithheldOther.forEach(r => {
       const htmltestStatus = statusByUrl.get(r.url);
@@ -431,11 +464,30 @@ if (notBrokenResults.length > 0 && !isManualMode) {
     });
   }
 
+  if (browserTemporaryOther.length > 0) {
+    console.log('\nℹ️  Browser showed a temporary maintenance page (503) but htmltest reported a different status:');
+    console.log('━'.repeat(60));
+    browserTemporaryOther.forEach(r => {
+      const htmltestStatus = statusByUrl.get(r.url);
+      console.log(`  - ${r.url}  (htmltest: ${htmltestStatus}, browser: ${r.status} maintenance page)`);
+      if (r.retryAfter) {
+        console.log(`    → Retry-After: ${r.retryAfter}`);
+      }
+      if (r.redirected) {
+        console.log(`    → Redirects to: ${r.finalUrl}`);
+      }
+    });
+  }
+
   if (connectionErrors.length > 0) {
     console.log('\n⚠️  htmltest had connection/TLS errors but browser got a response (investigate):');
     console.log('━'.repeat(60));
     connectionErrors.forEach(r => {
-      const browserState = r.reachable ? `${r.status} reachable` : `${r.status} gated`;
+      const browserState = r.reachable
+        ? `${r.status} reachable`
+        : r.withheld
+          ? `${r.status} gated`
+          : `${r.status} temporary`;
       console.log(`  - ${r.url}  (browser: ${browserState})`);
       if (r.redirected) {
         console.log(`    → Redirects to: ${r.finalUrl}`);
@@ -477,20 +529,21 @@ if (trulyBroken.length > 0) {
 console.log('\n' + '━'.repeat(60));
 
 // Exit with appropriate code
-// Note: 403/999/429 responses are withheld from the ignore list by policy but still represent
-// non-broken links (resource exists, just gated against automation), so they don't trigger
-// exit(1). Only genuinely broken links fail.
+// Note: 403/429/999 withheld responses and 503 maintenance pages stay visible in
+// the report but do not trigger exit(1). Only genuinely broken links fail.
 if (trulyBroken.length > 0) {
   console.log(`\n⚠️  ${trulyBroken.length} link(s) need manual attention\n`);
   process.exit(1);
 }
 
 if (isManualMode && notBrokenResults.length > 0) {
-  console.log(`\n✅ All provided URLs are accounted for (reachable or withheld)\n`);
+  console.log(`\n✅ All provided URLs are accounted for (reachable, withheld, or temporary)\n`);
+} else if (ignoreCandidates.length > 0 && temporaryResults.length > 0) {
+  console.log(`\n✅ All failed links are accounted for — update ignore list for reachable URLs; temporary maintenance pages need no ignore entry\n`);
 } else if (ignoreCandidates.length > 0) {
   console.log(`\n✅ All failed links reachable in browser - update ignore list\n`);
 } else if (notBrokenResults.length > 0) {
-  console.log(`\n✅ All failed links accounted for (reachable or withheld) - no ignore list updates suggested\n`);
+  console.log(`\n✅ All failed links accounted for (reachable, withheld, or temporary) - no ignore list updates suggested\n`);
 } else if (!isManualMode && htmltest429s.length > 0) {
   console.log(`\n✅ No genuinely broken links — all failures are rate-limited (429 bot-gated)\n`);
 }

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -309,16 +309,14 @@ const withheldResults = results.filter(r => r.withheld);
 const temporaryResults = results.filter(r => r.temporary);
 const broken = results.filter(r => !r.success);
 
-// HTTP 429 = rate-limited/bot-gated; resource exists but automation is throttled.
-// Like 403/429/999, these are not genuinely broken links. Separate from trulyBroken so
-// they don't cause false-positive exit(1) while remaining visible in the report.
+// HTTP 429 = rate-limited/bot-gated: both htmltest and browser were gated.
+// Drawn from withheldResults (browser confirmed gated) so that any 429 URL where
+// the browser found a genuine failure (404/500/TLS) stays in trulyBroken instead.
 // (Only meaningful in automated mode where htmltest status codes are available.)
 const htmltest429s = !isManualMode
-  ? broken.filter(r => statusByUrl.get(r.url) === 429)
+  ? withheldResults.filter(r => statusByUrl.get(r.url) === 429)
   : [];
-const trulyBroken = !isManualMode
-  ? broken.filter(r => statusByUrl.get(r.url) !== 429)
-  : broken;
+const trulyBroken = broken;
 
 console.log(`\n📊 Summary:`);
 if (isManualMode) {
@@ -330,7 +328,7 @@ if (isManualMode) {
 } else {
   console.log(`   Unique URLs from htmltest: ${failedUrls.length}`);
   console.log(`   ✅ Reachable in real browser: ${reachableResults.length}`);
-  console.log(`   ℹ️  Withheld (browser also gated): ${withheldResults.length}`);
+  console.log(`   ℹ️  Withheld (browser gated: 403/999): ${withheldResults.length - htmltest429s.length}`);
   console.log(`   ⏸️  Temporarily unavailable (503 maintenance): ${temporaryResults.length}`);
   if (htmltest429s.length > 0) {
     console.log(`   🚫 Rate-limited / bot-gated (429): ${htmltest429s.length}`);
@@ -367,8 +365,8 @@ if (!isManualMode) {
     const status = statusByUrl.get(r.url);
     return status !== 403 && status !== 999 && status !== null && status !== undefined;
   });
-  htmltest403s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 403);
-  htmltest999s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 999);
+  htmltest403s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 403 && !r.temporary);
+  htmltest999s = notBrokenResults.filter(r => statusByUrl.get(r.url) === 999 && !r.temporary);
   htmltest503Temporaries = temporaryResults.filter(r => statusByUrl.get(r.url) === 503);
   connectionErrors = notBrokenResults.filter(r => statusByUrl.get(r.url) === null || statusByUrl.get(r.url) === undefined);
   // Catch browser-withheld URLs whose htmltest status doesn't match any policy
@@ -500,7 +498,7 @@ if (notBrokenResults.length > 0 && !isManualMode) {
 }
 
 // 429-gated URLs are reported outside the notBrokenResults guard because
-// they appear in `broken` (browser also failed), not in `notBrokenResults`.
+// they are a subset of withheldResults and would duplicate that section's display.
 if (!isManualMode && htmltest429s.length > 0) {
   console.log('\nℹ️  htmltest reported 429 — rate-limited / bot-gated (not added to IgnoreURLs):');
   console.log('━'.repeat(60));

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -18,15 +18,39 @@ export async function verifyUrl(page, url) {
     });
 
     const status = response ? response.status() : 'NO_RESPONSE';
+    const headers = response ? response.headers() : {};
+    const retryAfter = headers['retry-after'];
 
     // Two distinct flavors of "not broken":
     //   reachable: 2xx — the page actually loaded for the browser
-    //   withheld: 403/999 — the resource exists but gates automated
-    //     clients. Same semantic class as a 403 from htmltest.
+    //   withheld: 403/429/999 — the resource exists but gates automated
+    //     clients. Same semantic class as those statuses from htmltest.
+    //   temporary: 503 maintenance page with strong signals such as
+    //     Retry-After or explicit maintenance-mode page content.
     // success keeps the broad "not broken" meaning so callers that only
     // care about pass/fail don't have to inspect both flags.
     const reachable = !!(response && response.ok());
-    const withheld = !!(response && (status === 403 || status === 999));
+    const withheld = !!(response && (status === 403 || status === 429 || status === 999));
+    let maintenanceSignals = [];
+    if (status === 503) {
+      if (retryAfter) {
+        maintenanceSignals.push(`Retry-After: ${retryAfter}`);
+      }
+
+      const pageHtml = (await page.content()).toLowerCase();
+      const maintenanceMarkers = [
+        'scheduled maintenance',
+        'under maintenance',
+        'maintenance mode',
+        'please check back soon',
+        'temporarily unavailable'
+      ];
+
+      if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {
+        maintenanceSignals.push('maintenance page content');
+      }
+    }
+    const temporary = status === 503 && maintenanceSignals.length > 0;
 
     return {
       url,
@@ -35,7 +59,10 @@ export async function verifyUrl(page, url) {
       redirected: page.url() !== url,
       reachable,
       withheld,
-      success: reachable || withheld
+      temporary,
+      retryAfter,
+      maintenanceSignals,
+      success: reachable || withheld || temporary
     };
   } catch (error) {
     return {
@@ -43,6 +70,7 @@ export async function verifyUrl(page, url) {
       error: error.message,
       reachable: false,
       withheld: false,
+      temporary: false,
       success: false
     };
   }

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -33,18 +33,21 @@ export async function verifyUrl(page, url) {
     const withheld = !!(response && (status === 403 || status === 429 || status === 999));
     let maintenanceSignals = [];
     if (status === 503) {
-      if (retryAfter) {
-        maintenanceSignals.push(`Retry-After: ${retryAfter}`);
-      } else {
-        const pageHtml = (await page.content()).toLowerCase();
-        const maintenanceMarkers = [
-          'scheduled maintenance',
-          'under maintenance',
-          'maintenance mode'
-        ];
+      // Require explicit maintenance-mode page content as the primary signal.
+      // Retry-After alone is too broad — servers also send it for overload,
+      // abuse mitigation, and transient outages. Only treat it as corroborating
+      // evidence when page content already confirms a maintenance window.
+      const pageHtml = (await page.content()).toLowerCase();
+      const maintenanceMarkers = [
+        'scheduled maintenance',
+        'under maintenance',
+        'maintenance mode'
+      ];
 
-        if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {
-          maintenanceSignals.push('maintenance page content');
+      if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {
+        maintenanceSignals.push('maintenance page content');
+        if (retryAfter) {
+          maintenanceSignals.push(`Retry-After: ${retryAfter}`);
         }
       }
     }

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -21,7 +21,7 @@ export async function verifyUrl(page, url) {
     const headers = response ? response.headers() : {};
     const retryAfter = headers['retry-after'];
 
-    // Two distinct flavors of "not broken":
+    // Three distinct flavors of "not broken":
     //   reachable: 2xx — the page actually loaded for the browser
     //   withheld: 403/429/999 — the resource exists but gates automated
     //     clients. Same semantic class as those statuses from htmltest.

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -25,8 +25,8 @@ export async function verifyUrl(page, url) {
     //   reachable: 2xx — the page actually loaded for the browser
     //   withheld: 403/999 — the resource exists but gates automated clients;
     //             429 — rate-limited/bot-gated (does NOT imply resource exists)
-    //   temporary: 503 maintenance page with strong signals such as
-    //     Retry-After or explicit maintenance-mode page content.
+    //   temporary: 503 maintenance page requiring explicit maintenance-mode
+    //     page content; Retry-After treated as corroborating evidence only.
     // success keeps the broad "not broken" meaning so callers that only
     // care about pass/fail don't have to inspect both flags.
     const reachable = !!(response && response.ok());

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -35,17 +35,17 @@ export async function verifyUrl(page, url) {
     if (status === 503) {
       if (retryAfter) {
         maintenanceSignals.push(`Retry-After: ${retryAfter}`);
-      }
+      } else {
+        const pageHtml = (await page.content()).toLowerCase();
+        const maintenanceMarkers = [
+          'scheduled maintenance',
+          'under maintenance',
+          'maintenance mode'
+        ];
 
-      const pageHtml = (await page.content()).toLowerCase();
-      const maintenanceMarkers = [
-        'scheduled maintenance',
-        'under maintenance',
-        'maintenance mode'
-      ];
-
-      if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {
-        maintenanceSignals.push('maintenance page content');
+        if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {
+          maintenanceSignals.push('maintenance page content');
+        }
       }
     }
     const temporary = status === 503 && maintenanceSignals.length > 0;

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -42,8 +42,7 @@ export async function verifyUrl(page, url) {
         'scheduled maintenance',
         'under maintenance',
         'maintenance mode',
-        'please check back soon',
-        'temporarily unavailable'
+        'please check back soon'
       ];
 
       if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -23,8 +23,8 @@ export async function verifyUrl(page, url) {
 
     // Three distinct flavors of "not broken":
     //   reachable: 2xx — the page actually loaded for the browser
-    //   withheld: 403/429/999 — the resource exists but gates automated
-    //     clients. Same semantic class as those statuses from htmltest.
+    //   withheld: 403/999 — the resource exists but gates automated clients;
+    //             429 — rate-limited/bot-gated (does NOT imply resource exists)
     //   temporary: 503 maintenance page with strong signals such as
     //     Retry-After or explicit maintenance-mode page content.
     // success keeps the broad "not broken" meaning so callers that only

--- a/scripts/lib/verify-url.js
+++ b/scripts/lib/verify-url.js
@@ -41,8 +41,7 @@ export async function verifyUrl(page, url) {
       const maintenanceMarkers = [
         'scheduled maintenance',
         'under maintenance',
-        'maintenance mode',
-        'please check back soon'
+        'maintenance mode'
       ];
 
       if (maintenanceMarkers.some(marker => pageHtml.includes(marker))) {

--- a/src/content/blog/2021-01-18-two-guys-watch-a-burning-house.md
+++ b/src/content/blog/2021-01-18-two-guys-watch-a-burning-house.md
@@ -79,7 +79,7 @@ some edits for clarity.
 
 I forget when in 1973 the Skrinak family house caught on fire. I’m guessing it was in late Spring, but that was so long ago. I do remember this &mdash; it was warm enough for my 11-year-old self to be on the roof of my house in my pajamas.
 
-I went to bed after an ordinary day, around 9 PM. We had largely restored our house after the devastating 1972 flood from <a href="https://www.timesleader.com/news/local/663873/45-years-later-agnes-still-on-peoples-minds">Hurricane Agnes</a> that ravaged the Wyoming valley. The neighborhood had largely returned to its old Kingston self. We had also recently reshuffled the second floor so all of us siblings were able to get our separate rooms. Not that I minded sharing with my brothers, as many of us youngest siblings love our sibling’s company. Unlike now, a kid per room was a luxury.
+I went to bed after an ordinary day, around 9 PM. We had largely restored our house after the devastating 1972 flood from Hurricane Agnes that ravaged the Wyoming valley. The neighborhood had largely returned to its old Kingston self. We had also recently reshuffled the second floor so all of us siblings were able to get our separate rooms. Not that I minded sharing with my brothers, as many of us youngest siblings love our sibling’s company. Unlike now, a kid per room was a luxury.
 
 As for my bedroom, I had three smallish windows. With the room darkened for sleep, I could see the streetlight-diffused night sky illuminate my room in a row of three rectangles. As I drifted off to sleep, I’d peek my eyes open and closed as I settled in.
 


### PR DESCRIPTION
Promotes staging → main. Merges PR #112.

## Changes

### Scripts / configuration
- Classifies 503 maintenance pages as temporary (not broken); requires explicit maintenance-mode page content as primary signal; `Retry-After` is corroborating evidence only — prevents overload/abuse 503s from masking real failures
- Removes `'temporarily unavailable'` and `'please check back soon'` from maintenance markers (too generic)
- Removes `linkedin.com`/`ubuntu.com` whole-host IgnoreURLs — two-tier system handles these without hiding real broken URLs
- Fixes 429 withheld log message: now says 'Rate-limited / bot-gated'
- Clarifies `browserWithheldOther` section header
- Moves `htmltest429s` into withheld bucket; `trulyBroken` uses browser as ground truth
- Removes unreachable `else if (htmltest429s.length > 0)` branch
- Fixes summary counts by browser status (`withheld403_999Count`, `withheld429Count`)
- Excludes htmltest-429 from `browserWithheldOther` to prevent duplicate output
- Fixes `verify-url.js` inline comment: three flavors; 403/999 vs 429 existence semantics; Retry-After corroborating-only

### Documentation
- Updates `docs/link-checking.md`: three-outcome model (Reachable/Withheld/Temporary); 429/503-maintenance policy; bot-blocking table; accurate IgnoreURLs note; Retry-After corroborating-only; removes stale `linkedin.com` example; broadens Reachable description; syncs Policy Exclusions bullet with implementation

### Agent instructions
- Updates `CLAUDE.md`: approval-gate rules with workflow exception and cross-reference; commit/push qualifiers in Making Changes; removes conflicting 'Commit after each working change' from Code Changes; narrows User authority precedence rule

### Blog content
- `src/content/blog/2021-01-18-two-guys-watch-a-burning-house.md`: adds `disqusId` frontmatter; removes broken Hurricane Agnes link (plain text retained)