### PR TITLE
fix(nav): vertically center About dropdown in desktop nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -94,7 +94,7 @@ const isActive = (path: string) => {
           </a>
         </li>
         {/* Desktop: About <details> disclosure — works on hover, focus, tap (hidden on mobile) */}
-        <li class="relative col-span-2 hidden sm:block">
+        <li class="relative col-span-2 hidden sm:flex sm:items-center">
           <details id="about-menu" class="group/about">
             <summary
               class:list={[


### PR DESCRIPTION
## What

The About `<details>`/`<summary>` disclosure in the desktop nav was rendering higher than the other nav items (Posts, Tags, Presentations).

## Root cause

The `<li>` containing the About `<details>` was set to `sm:block`. In the parent flex row (`<ul id="menu-items">`), flex items stretch to the container height by default (`align-items: stretch`). With `display: block`, the `<details>` element filled the full stretched height and `<summary>` pinned to the top — making "About" appear above the baseline of sibling nav items.

## Fix

```diff
- <li class="relative col-span-2 hidden sm:block">
+ <li class="relative col-span-2 hidden sm:flex sm:items-center">
```

Making the `<li>` a flex container with `items-center` centers the `<details>` child vertically, matching the visual baseline of the other nav links.

## Verified

- No effect on mobile (the `hidden` / `sm:` pattern keeps this desktop-only)
- Absolute-positioned dropdown still anchored correctly via `position: relative` on `<li>`
- Tailwind `group-open/about:rotate-180` chevron unaffected
- `npm run build` passes (154 pages)
- Visual regression baselines regenerated locally (snapshots are gitignored)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>