### PR TITLE
fix(nav): vertically center About dropdown in desktop nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -94,7 +94,7 @@ const isActive = (path: string) => {
           </a>
         </li>
         {/* Desktop: About <details> disclosure — works on hover, focus, tap (hidden on mobile) */}
-        <li class="relative col-span-2 hidden sm:block">
+        <li class="relative col-span-2 hidden sm:flex sm:items-center">
           <details id="about-menu" class="group/about">
             <summary
               class:list={[


### PR DESCRIPTION
## What

Fixes a visual alignment bug: the About `<details>`/`<summary>` nav item rendered higher than its siblings (Posts, Tags, Presentations) on desktop.

## Root cause

`sm:block` on the wrapping `<li>` caused `<details>` to stretch to the full flex-item height, with `<summary>` pinned to the top. The other nav items' `<a>` tags have `py-1` padding giving the illusion of centering, but `<summary>` had none.

## Fix

```diff
- <li class="relative col-span-2 hidden sm:block">
+ <li class="relative col-span-2 hidden sm:flex sm:items-center">
```

`sm:flex sm:items-center` makes the `<li>` a flex container, centering `<details>` vertically to match sibling nav items.

## Verified

- Mobile unaffected (`hidden` / `sm:` scopes this to desktop only)
- Dropdown absolute positioning still anchored via `position: relative` on `<li>`
- Tailwind `group-open/about:rotate-180` chevron unaffected
- `npm run build` passes (154 pages)
- Visual regression baselines regenerated locally

Promotes staging commit `b91ee5c` to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)