### PR TITLE
fix(content): replace Kramdown {: .notice--info} syntax with HTML divs

### DIFF
--- a/src/content/blog/2018-04-07-drupalcon-nashville-2018.md
+++ b/src/content/blog/2018-04-07-drupalcon-nashville-2018.md
@@ -17,8 +17,7 @@ I will be leading two sessions at the [DrupalCon Higher Education Summit](https:
 
 You can find all the virtual directory for all the Higher Education Summit Session notes [here](https://drive.google.com/drive/folders/1uaFfgSob8VHlIpvb1WNMi_UdYdrYXwTA).  
 
-**Note:** these agenda items are not hard-and-fast discussion items. Depending on session attendees and details I cannot anticipate, these discussions tend to grow a life of their own. I find that nearly always, the actual discussion turns out far better than I anticipate. *Caveat lector.*
-{: .notice--info}
+<div style="padding: 1rem; margin-bottom: 1.5rem; border-left: 4px solid #3498db; background-color: #d5edf7; border-radius: 0 3px 3px 0;"><strong>Note:</strong> these agenda items are not hard-and-fast discussion items. Depending on session attendees and details I cannot anticipate, these discussions tend to grow a life of their own. I find that nearly always, the actual discussion turns out far better than I anticipate. <em>Caveat lector.</em></div>
 
 ## Session 1; 11:20 AM &ndash; 12:20 PM
 ### Continuous Integration / Continuous Development Strategies

--- a/src/content/blog/2018-10-28-how-to-restaurant.md
+++ b/src/content/blog/2018-10-28-how-to-restaurant.md
@@ -73,8 +73,7 @@ I&#39;ve found Mexican restaurants to be generally the most accommodating of LCH
 
 When life happens, what to do? Remember the axiom, less is more? That's right, don't eat. For example, if you're at a faux-Italian chain, and it's all bread, pasta, sugar and rapeseed oil? You can order an unsweetened tea or a diet soda, and enjoy the company. Order a house salad and take your time eating it. Skip the croutons, of course. If you've been on LCHF for a long enough period of time, this will not be a problem. My personal experience was this was difficult at first. _"Kyle, aren't you hungry?"_ It was a fair enough question, since, previously, I ate and ate and ate. Now, on LCHF, my satiety is such that I can, and do, skip meals. It's not willpower, per se, I've adapted my body. I don't _have to_ eat now, and not merely because everyone else is.
 
-Remember, we're not dogs. We don't have to reward ourselves with food, nor eat it because we see it.
-{: .notice--info}
+<div style="padding: 1rem; margin-bottom: 1.5rem; border-left: 4px solid #3498db; background-color: #d5edf7; border-radius: 0 3px 3px 0;">Remember, we're not dogs. We don't have to reward ourselves with food, nor eat it because we see it.</div>
 
 It’s that simple. If they have real butter, they are the real deal. I would like to think that LCHF’er and foodie, alike, would agree on this?
 

--- a/src/content/blog/2018-10-31-a-pound-of-flesh-and-a-hot-tub.md
+++ b/src/content/blog/2018-10-31-a-pound-of-flesh-and-a-hot-tub.md
@@ -54,5 +54,4 @@ Minutes pass…
 
 “Never mind.”
 
-__postscript:__ I wrote this in February, 2018. My skin has tightened up since then, I’m pleased to report. Perhaps related to autophagy? That’s for another post.
-{: .notice--info}
+<div style="padding: 1rem; margin-bottom: 1.5rem; border-left: 4px solid #3498db; background-color: #d5edf7; border-radius: 0 3px 3px 0;"><strong>Postscript:</strong> I wrote this in February, 2018. My skin has tightened up since then, I’m pleased to report. Perhaps related to autophagy? That’s for another post.</div>


### PR DESCRIPTION
## Summary

Resolves #129 — three blog posts inherited Jekyll/Kramdown attribute syntax (`{: .notice--info}`) that renders as literal text in Astro since no Kramdown-compatible plugin is loaded.

## Changes

| File | Fix |
|---|---|
| `2018-10-28-how-to-restaurant.md` | Converted trailing `{: .notice--info}` to inline-styled `<div>` |
| `2018-10-31-a-pound-of-flesh-and-a-hot-tub.md` | Converted postscript paragraph + `{: .notice--info}` to inline-styled `<div>` |
| `2018-04-07-drupalcon-nashville-2018.md` | Converted Note paragraph + `{: .notice--info}` to inline-styled `<div>` |

Each occurrence is replaced with a `<div>` using inline styles matching the visual appearance of the original `.notice--info` class (blue left border, light blue background), consistent with the pattern used in other migrated posts (e.g. `2021-01-19-shinleaf-campsite.md`). Inline markdown inside the div is converted to HTML since remark does not process markdown inside raw HTML blocks.

## Testing

- `npm run build` — passes
- No visual regression on unrelated pages expected