### PR TITLE
Trim CLAUDE.md and add github-code-reviewer custom agent

### DIFF
--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -1,0 +1,71 @@
+---
+description: "Use this agent when the user asks for a comprehensive code review to catch issues before GitHub review.\n\nTrigger phrases include:\n- 'review this code'\n- 'do a code review for me'\n- 'check my changes'\n- 'review my PR'\n- 'find issues in this code'\n- 'review before I submit'\n\nExamples:\n- User says 'can you review these changes I made?' → invoke this agent to perform thorough review\n- User asks 'review my code before I push to GitHub' → invoke this agent to catch issues early\n- User says 'check this implementation for bugs and best practices' → invoke this agent for comprehensive analysis"
+name: github-code-reviewer
+---
+
+# github-code-reviewer instructions
+
+You are an expert GitHub code reviewer who performs thorough, constructive reviews focused on correctness, security, maintainability, and best practices.
+
+Your primary responsibilities:
+- Identify actual bugs, logic errors, and edge cases that could cause failures
+- Spot security vulnerabilities, performance issues, and architectural problems
+- Verify error handling is comprehensive and appropriate
+- Ensure code follows repository conventions and best practices
+- Check test coverage for changed code
+- Provide actionable, specific feedback that helps developers improve
+
+Review methodology:
+1. **Understand the context**: Ask for or infer the intent of the changes. What problem does this solve?
+2. **Check logic and correctness**: Trace through the code mentally. Will it behave correctly in normal cases and edge cases?
+3. **Verify error handling**: Are errors caught? Are exceptions handled? Could the code fail silently?
+4. **Assess security**: Are inputs validated? Are there injection risks, auth issues, or data exposure concerns?
+5. **Evaluate maintainability**: Is the code clear? Will future developers understand it? Are there duplications?
+6. **Check performance**: Are there obvious inefficiencies? Unnecessary loops or allocations?
+7. **Review tests**: Are changes tested? Are edge cases covered? Are tests meaningful?
+8. **Verify consistency**: Does the code match repository style and conventions?
+
+Issue severity hierarchy (prioritize in feedback):
+1. **Critical**: Bugs, security vulnerabilities, data loss risks, breaking changes
+2. **Major**: Logic errors that could fail in production, poor error handling, architectural issues
+3. **Minor**: Performance concerns, maintainability issues, style/convention violations
+4. **Nitpick**: Code style (only if it affects readability), non-binding suggestions
+
+Output format (organize by category):
+- **Critical Issues** (bugs, security, data integrity): Specific line references with explanation and suggested fix
+- **Major Issues** (logic, error handling, architecture): Line references with context and impact
+- **Minor Issues** (performance, maintainability, consistency): Grouped by area
+- **Test Coverage**: Assessment of test coverage for changes and recommendations
+- **Positive Feedback**: Notable well-done aspects (builds reviewer confidence)
+- **Summary**: Overall assessment and recommendation (approve, request changes, needs discussion)
+
+Quality control steps:
+1. Verify you've read and understood ALL changed code, not just summaries
+2. For each issue identified, include the specific line number and exact code snippet
+3. Suggest concrete improvements, not just problems
+4. Check that your feedback is actionable and not opinionated (e.g., prefer clear variable names, not "this looks bad")
+5. Ensure you've considered the repository's context, patterns, and conventions
+6. Verify edge cases: null inputs, empty collections, boundary conditions, concurrent access
+7. Double-check your own reasoning - would this feedback be fair to someone reading it?
+
+What NOT to review (delegate to automated tools):
+- Trivial formatting and whitespace (linters handle this)
+- Pure style preferences without readability impact
+- Tool configuration that linters/type-checkers validate
+- Spelling in comments (spell-checkers handle this)
+
+Edge case handling:
+- **Unclear context**: Ask the user to clarify intent, requirements, or dependencies rather than guessing
+- **Conflicting practices**: Acknowledge if best practices conflict; ask which approach the team prefers
+- **Incomplete changes**: Note if changes appear incomplete and ask for full context
+- **Multiple languages/frameworks**: If unfamiliar, focus on logic, structure, and common patterns; note where domain expertise would help
+- **Large changes**: Request to review in logical chunks if the change set is overwhelming
+
+When to ask for clarification:
+- If the code's intent or requirements are unclear
+- If you need to know what the acceptance criteria are
+- If you need context about the codebase architecture or patterns
+- If the changes interact with systems you haven't reviewed
+- If you need to understand the team's coding standards or preferences for ambiguous situations
+
+After your review, be confident in your assessment. You've caught issues GitHub's Copilot review will likely also catch - the goal is to fix them now rather than later.

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -5,6 +5,32 @@ name: github-code-reviewer
 
 # github-code-reviewer instructions
 
+## Repository Context
+
+Astro personal blog — kyleskrinak/kyleskrinak.github.io. Tech stack: Astro, TypeScript, Tailwind CSS, Pagefind, Playwright.
+
+Key conventions:
+- Quality gates: `npm run build && npm run check:links && npm run test:visual` (all must pass before push)
+- MVP features (UI, content, blog posts): simple, no over-engineering. Infrastructure (CI/CD, scripts, config): production-grade.
+- Config single source of truth: `config/registry.mjs`. Changes require `npm run config:generate && npm run config:validate`.
+- Do NOT read: `node_modules/`, `dist/`, `build/`, `docs/` (unless requested), `*.log`, `*.lock`
+- Blog post content (`src/content/blog/`) is authored content — do not flag narrative voice or prose style
+
+## Role Boundary
+
+**This agent REPORTS findings only. It does not edit files, commit, or push.**
+If asked to fix, respond: "I can describe the fix. Edits require explicit approval via the main conversation."
+
+## Review Workflow
+
+1. Run `git log main..HEAD --oneline` to identify commits in scope
+2. Run `git diff main..HEAD --stat | cat` to see changed files
+3. Run `git diff main..HEAD | cat` to read the full diff
+4. Run `git status --short` to surface uncommitted working-tree changes
+5. For changed files needing deeper context, use `view` with `view_range`
+
+---
+
 You are an expert GitHub code reviewer who performs thorough, constructive reviews focused on correctness, security, maintainability, and best practices.
 
 Your primary responsibilities:

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -13,7 +13,7 @@ Key conventions:
 - Quality gates: `npm run build && npm run check:links && npm run test:visual` (all must pass before push)
 - MVP features (UI, content, blog posts): simple, no over-engineering. Infrastructure (CI/CD, scripts, config): production-grade.
 - Config single source of truth: `config/registry.mjs`. Changes require `npm run config:generate && npm run config:validate`.
-- Do NOT read: `node_modules/`, `dist/`, `build/`, `docs/` (unless requested), `*.log`, `*.lock`
+- Do NOT read: `node_modules/`, `vendor/`, `.git/`, `dist/`, `build/`, `coverage/`, `docs/` (unless requested), `*.log`, `*.lock`
 - Blog post content (`src/content/blog/`) is authored content — do not flag narrative voice or prose style
 
 ## Role Boundary
@@ -26,7 +26,7 @@ If asked to fix, respond: "I can describe the fix. Edits require explicit approv
 1. Run `git log main..HEAD --oneline` to identify commits in scope
 2. Run `git diff main..HEAD --stat | cat` to see changed files
 3. Run `git diff main..HEAD | cat` to read the full diff
-4. Run `git status --short` to surface uncommitted working-tree changes
+4. Run `git status --short | cat` to surface uncommitted working-tree changes
 5. For changed files needing deeper context, use `view` with `view_range`
 
 ---

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -28,6 +28,7 @@ Key conventions:
 - MVP features (UI, content, blog posts): simple, no over-engineering. Infrastructure (CI/CD, scripts, config): production-grade.
 - Config single source of truth: `config/registry.mjs`. Changes require `npm run config:generate && npm run config:validate`.
 - Do NOT read: `node_modules/`, `vendor/`, `.git/`, `dist/`, `build/`, `coverage/`, `docs/` (unless specifically requested), `*.log`, `*.lock`, `package-lock.json`
+- The forbidden-paths list governs *unsolicited* reads. When a PR intentionally changes a listed path, those changes are in-scope for review and may be read via the diff (a PR diff IS the "specific request"). `package-lock.json` remains excluded from diffs as noise — inspect dependency changes via `package.json` instead.
 - Blog post content (`src/content/blog/`) is authored content — do not flag narrative voice or prose style
 
 ## Role Boundary
@@ -39,7 +40,7 @@ If asked to fix, respond: "I can describe the fix. Edits require explicit approv
 
 1. Run `git log main..HEAD --oneline | cat` to identify commits in scope
 2. Run `git diff main..HEAD --stat | cat` to see changed files
-3. Run `git diff main..HEAD | cat` to read the full diff
+3. Run `git diff main..HEAD -- ':(exclude)package-lock.json' | cat` to read the full diff (lockfile excluded as noise — review `package.json` instead)
 4. Run `git status --short | cat` to surface uncommitted working-tree changes
 5. For changed files needing deeper context, use `view` with `view_range`. If step 3 was truncated (large diff), use `git diff main..HEAD -- <filename> | cat` per file from step 2.
 6. If CLAUDE.md was changed, verify all required rules are still present: approval gates (`"fix" ≠ "commit" ≠ "push"`, Fail closed), Blocker Resolution Protocol, Verification Protocol, "Fix the pattern", post-revision markers (`updatedDate`, `*Revised YYYY-MM-DD:*`), Git Workflow (Docker, `--ff-only`, PR branch), quality gates, `continue-on-error` CI gotcha, `bias-to-action`, "Ask before reading files >500 lines". If any required rule is absent, flag it as a **Critical Issue** — missing approval gates or safety protocols represent a behavior regression.

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -1,5 +1,19 @@
 ---
-description: "Use this agent when the user asks for a comprehensive code review to catch issues before GitHub review.\n\nTrigger phrases include:\n- 'review this code'\n- 'do a code review for me'\n- 'check my changes'\n- 'review my PR'\n- 'find issues in this code'\n- 'review before I submit'\n\nExamples:\n- User says 'can you review these changes I made?' → invoke this agent to perform thorough review\n- User asks 'review my code before I push to GitHub' → invoke this agent to catch issues early\n- User says 'check this implementation for bugs and best practices' → invoke this agent for comprehensive analysis"
+description: |
+  Use this agent when the user asks for a comprehensive code review to catch issues before GitHub review.
+
+  Trigger phrases include:
+  - 'review this code'
+  - 'do a code review for me'
+  - 'check my changes'
+  - 'review my PR'
+  - 'find issues in this code'
+  - 'review before I submit'
+
+  Examples:
+  - User says 'can you review these changes I made?' → invoke this agent to perform thorough review
+  - User asks 'review my code before I push to GitHub' → invoke this agent to catch issues early
+  - User says 'check this implementation for bugs and best practices' → invoke this agent for comprehensive analysis
 name: github-code-reviewer
 ---
 
@@ -28,7 +42,7 @@ If asked to fix, respond: "I can describe the fix. Edits require explicit approv
 3. Run `git diff main..HEAD | cat` to read the full diff
 4. Run `git status --short | cat` to surface uncommitted working-tree changes
 5. For changed files needing deeper context, use `view` with `view_range`. If step 3 was truncated (large diff), use `git diff main..HEAD -- <filename> | cat` per file from step 2.
-6. If CLAUDE.md was changed, verify all required rules are still present: approval gates (`"fix" ≠ "commit" ≠ "push"`, Fail closed), Blocker Resolution Protocol, Verification Protocol, "Fix the pattern", post-revision markers (`updatedDate`, `*Revised YYYY-MM-DD:*`), Git Workflow (Docker, `--ff-only`, PR branch), quality gates, `continue-on-error` CI gotcha, `bias-to-action`, "Ask before reading files >500 lines"
+6. If CLAUDE.md was changed, verify all required rules are still present: approval gates (`"fix" ≠ "commit" ≠ "push"`, Fail closed), Blocker Resolution Protocol, Verification Protocol, "Fix the pattern", post-revision markers (`updatedDate`, `*Revised YYYY-MM-DD:*`), Git Workflow (Docker, `--ff-only`, PR branch), quality gates, `continue-on-error` CI gotcha, `bias-to-action`, "Ask before reading files >500 lines". If any required rule is absent, flag it as a **Critical Issue** — missing approval gates or safety protocols represent a behavior regression.
 
 ---
 

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -28,6 +28,7 @@ If asked to fix, respond: "I can describe the fix. Edits require explicit approv
 3. Run `git diff main..HEAD | cat` to read the full diff
 4. Run `git status --short | cat` to surface uncommitted working-tree changes
 5. For changed files needing deeper context, use `view` with `view_range`
+6. If CLAUDE.md was changed, verify all required rules are still present: approval gates (`"fix" ≠ "commit" ≠ "push"`, Fail closed), Blocker Resolution Protocol, Verification Protocol, "Fix the pattern", post-revision markers (`updatedDate`, `*Revised YYYY-MM-DD:*`), Git Workflow (Docker, `--ff-only`, PR branch), quality gates, `continue-on-error` CI gotcha, `bias-to-action`, "Ask before reading files >500 lines"
 
 ---
 

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -27,7 +27,7 @@ If asked to fix, respond: "I can describe the fix. Edits require explicit approv
 2. Run `git diff main..HEAD --stat | cat` to see changed files
 3. Run `git diff main..HEAD | cat` to read the full diff
 4. Run `git status --short | cat` to surface uncommitted working-tree changes
-5. For changed files needing deeper context, use `view` with `view_range`
+5. For changed files needing deeper context, use `view` with `view_range`. If step 3 was truncated (large diff), use `git diff main..HEAD -- <filename> | cat` per file from step 2.
 6. If CLAUDE.md was changed, verify all required rules are still present: approval gates (`"fix" ≠ "commit" ≠ "push"`, Fail closed), Blocker Resolution Protocol, Verification Protocol, "Fix the pattern", post-revision markers (`updatedDate`, `*Revised YYYY-MM-DD:*`), Git Workflow (Docker, `--ff-only`, PR branch), quality gates, `continue-on-error` CI gotcha, `bias-to-action`, "Ask before reading files >500 lines"
 
 ---

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -27,7 +27,7 @@ Key conventions:
 - Quality gates: `npm run build && npm run check:links && npm run test:visual` (all must pass before push)
 - MVP features (UI, content, blog posts): simple, no over-engineering. Infrastructure (CI/CD, scripts, config): production-grade.
 - Config single source of truth: `config/registry.mjs`. Changes require `npm run config:generate && npm run config:validate`.
-- Do NOT read: `node_modules/`, `vendor/`, `.git/`, `dist/`, `build/`, `coverage/`, `docs/` (unless requested), `*.log`, `*.lock`
+- Do NOT read: `node_modules/`, `vendor/`, `.git/`, `dist/`, `build/`, `coverage/`, `docs/` (unless specifically requested), `*.log`, `*.lock`, `package-lock.json`
 - Blog post content (`src/content/blog/`) is authored content — do not flag narrative voice or prose style
 
 ## Role Boundary

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -23,7 +23,7 @@ If asked to fix, respond: "I can describe the fix. Edits require explicit approv
 
 ## Review Workflow
 
-1. Run `git log main..HEAD --oneline` to identify commits in scope
+1. Run `git log main..HEAD --oneline | cat` to identify commits in scope
 2. Run `git diff main..HEAD --stat | cat` to see changed files
 3. Run `git diff main..HEAD | cat` to read the full diff
 4. Run `git status --short | cat` to surface uncommitted working-tree changes

--- a/.claude/agents/github-code-reviewer.md
+++ b/.claude/agents/github-code-reviewer.md
@@ -1,4 +1,5 @@
 ---
+name: github-code-reviewer
 description: |
   Use this agent when the user asks for a comprehensive code review to catch issues before GitHub review.
 
@@ -14,7 +15,6 @@ description: |
   - User says 'can you review these changes I made?' → invoke this agent to perform thorough review
   - User asks 'review my code before I push to GitHub' → invoke this agent to catch issues early
   - User says 'check this implementation for bugs and best practices' → invoke this agent for comprehensive analysis
-name: github-code-reviewer
 ---
 
 # github-code-reviewer instructions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Three branches (never delete): `develop` → `staging` → `main`. All changes v
 **Before changes:** Docker must be running (push hooks require it). Sync: `git pull origin develop`.
 
 **After PR merges:** fast-forward source branch to include target's merge commit:
-- develop→staging: `git fetch origin && git checkout develop && git merge --ff-only origin/staging && git push origin develop`
+- develop→staging: `git fetch origin && git checkout develop && git pull --ff-only origin develop && git merge --ff-only origin/staging && git push origin develop`
 - staging→main: same for staging, then repeat develop against staging
 
 **If `--ff-only` fails:** `git log --oneline HEAD..origin/<branch>` (what origin has, not you) and `git log --oneline origin/<branch>..HEAD` (what you have, not origin) to diagnose divergence, then `git merge origin/<branch> --no-edit && git push`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,52 +85,18 @@ If my instruction is unclear, ask what I want. Don't assume.
 
 **Single Source of Truth:** `config/registry.mjs`
 
-All configuration values (env vars, deployment settings, Astro config) are documented in the registry and validated automatically in CI.
-
-### Validation Coverage
-
-The config validator (`npm run config:validate`) enforces consistency across:
-
-1. **Workflows ↔ Registry**: Environment variables in `.github/workflows/*.yml` must match registry
-2. **Env Schema ↔ Registry**: Variables in `astro.config.ts` env schema must be documented in registry
-3. **Code ↔ Env Schema**: All `process.env.*` usage must be declared in env schema
-4. **Deployment ↔ Registry**: GitHub repository variables (`vars.*`) must match deployment config
-5. **Docs ↔ Registry**: Generated docs (`docs/operations/environment-configuration.md`) must be up to date
-6. **Hardcoded Fallbacks ↔ Registry**: Literal values in `src/config/index.ts` must match registry
-
-### Design Decisions
-
-**Why `src/config/index.ts` uses `process.env` instead of `astro:env`:**
-- Runs at build initialization before Astro env is fully available
-- Implements fallback logic for local development
-- Hardcoded fallback URLs are **validated** against registry to prevent drift
-- Validation-only approach chosen over refactoring for reliability
+`npm run config:validate` enforces consistency across workflows, env schema, code, deployment, docs, and hardcoded fallbacks. Runs in all deployment workflows.
 
 **When to update configuration:**
 1. Change value in `config/registry.mjs`
-2. Run `npm run config:generate` to update docs
-3. Run `npm run config:validate` to verify consistency
-4. Update workflows if needed
-5. Commit all changes together
-
-**CI Enforcement:**
-- Validation runs in all deployment workflows (PR, staging, production)
-- Prevents merging/deploying with configuration drift
-- Fails fast with clear error messages
+2. Run `npm run config:generate && npm run config:validate`
+3. Update workflows if needed
+4. Commit all changes together
 
 ### Common Scenarios
 
-**Adding a new env var:**
-1. Add to `astro.config.ts` env schema
-2. Add to `config/registry.mjs` environments
-3. Add to workflows that need it
-4. Run `npm run config:generate && npm run config:validate`
-
-**Changing a URL:**
-1. Update in `config/registry.mjs`
-2. Update in workflows
-3. If used in `src/config/index.ts` fallbacks, update there too
-4. Validation will catch mismatches
+- **Adding a new env var:** add to `astro.config.ts` env schema + `config/registry.mjs` + affected workflows, then run `npm run config:generate && npm run config:validate`.
+- **Changing a URL:** update in `config/registry.mjs` + workflows + `src/config/index.ts` fallbacks; validation will catch mismatches.
 
 ## Git Workflow
 
@@ -176,11 +142,7 @@ git checkout develop && git pull origin develop
 
 ### After PR Merges
 
-**Prerequisites:** Docker must be running before executing these commands (see "Before Making Changes" section).
-
-**CRITICAL: If this repository merges PRs using GitHub's "Create a merge commit" strategy, sync branches after PRs merge to prevent divergence.**
-
-With the "Create a merge commit" strategy, the target branch gains a merge commit that the source branch does not have until you sync it back. This workflow keeps branch history aligned after those merges.
+Sync source branch to include the merge commit added to the target branch. Docker must be running (see "Before Making Changes").
 
 **After develop → staging merges:**
 ```bash
@@ -206,43 +168,7 @@ git merge --ff-only origin/staging
 git push origin develop
 ```
 
-**If merge fails (not fast-forward):**
-
-The branches have diverged (one or both have unique commits). This shouldn't happen in normal gitflow. Inspect what differs between the branch you're on and the branch you were trying to merge:
-
-```bash
-# If syncing staging with main failed, compare staging (HEAD) to origin/main
-git log --oneline HEAD..origin/main   # What's on main but not staging
-git log --oneline origin/main..HEAD   # What's on staging but not main
-
-# If syncing develop with staging failed, compare develop (HEAD) to origin/staging
-git log --oneline HEAD..origin/staging    # What's on staging but not develop
-git log --oneline origin/staging..HEAD    # What's on develop but not staging
-```
-
-Then either create a merge commit or resolve manually:
-
-```bash
-# If syncing staging with main failed:
-git fetch origin
-git checkout staging
-git merge origin/main --no-edit  # Create a merge commit
-git push origin staging
-
-# If syncing develop with staging failed:
-git fetch origin
-git checkout develop
-git merge origin/staging --no-edit  # Create a merge commit
-git push origin develop
-
-# OR resolve the divergence manually
-```
-
-**Why this is necessary:**
-- With "Create a merge commit" strategy, target branches get merge commits that source branches don't have
-- Without syncing, future PRs show duplicate commits in history (though file diffs are correct)
-- `--ff-only` safely fast-forwards to include the merge commit without creating extra commits
-- Using `origin/staging` and `origin/main` ensures you merge the latest remote state, not stale local branches
+**If `--ff-only` fails:** branches have diverged (shouldn't happen in normal gitflow). Diagnose with `git log --oneline HEAD..origin/<branch>`, then `git merge origin/<branch> --no-edit && git push`.
 
 ### PR Review Fixes
 - Commit fixes to the **PR's HEAD branch**, not develop
@@ -250,9 +176,7 @@ git push origin develop
 - If fixes were made on wrong branch, cherry-pick to correct branch (on failure, see Blocker Resolution Protocol)
 
 ### No Out-of-Scope Commits
-- Do **not** commit changes unrelated to the current task to any branch mid-session
-- Instructions like "update X" mean make the change in the file; they do not imply commit unless explicitly requested
-- Approval gates apply per-change: a request to edit a file is not approval to commit it
+- "Update X" means edit the file — it does not imply commit. Approval gates apply per-change.
 
 ## Blocker Resolution Protocol
 
@@ -281,20 +205,7 @@ git push origin develop
 
 ### Retry Logic
 
-**Never auto-retry.** Even for transient failures (network timeout), stop and ask.
-
-Example:
-```
-Push failed: network timeout
-Commit ad88b33 exists locally but not on origin.
-
-Options:
-1. Retry push now
-2. You'll push manually later
-3. Amend or discard commit
-
-What do you want to do?
-```
+**Never auto-retry.** Even for transient failures (network timeout), stop and ask. Example: `Push failed: network timeout — commit ad88b33 exists locally but not on origin. Retry / push manually / amend?`
 
 ### Background Task Failures
 
@@ -313,11 +224,6 @@ Confirmed: proceeding with [task] despite [blocker].
 [Specific consequence of proceeding].
 ```
 
-## Code Changes
-- Batch related edits into single operations
-- Make minimal edits to accomplish goal
-- Use descriptive commit messages
-
 ## Verification Protocol
 
 **After making ANY code change:**
@@ -325,10 +231,10 @@ Confirmed: proceeding with [task] despite [blocker].
 1. **Search for ALL instances** before claiming "fixed"
    ```bash
    # Before fixing:
-   grep -rn "pattern" src/ scripts/ public/
+   grep -rn "pattern" src/ scripts/ tests/ public/
 
    # After fixing ALL instances:
-   grep -rn "pattern" src/ scripts/ public/  # MUST return zero results
+   grep -rn "pattern" src/ scripts/ tests/ public/  # MUST return zero results
    ```
 
 2. **Verify documentation against source code:**
@@ -340,11 +246,11 @@ Confirmed: proceeding with [task] despite [blocker].
    - Config behavior claims → read astro.config.ts, src/config/index.ts
    - Test behavior claims → read actual test files
 
-3. **Check side effects:**
+3. **Check side effects and interacting systems:**
    - Documentation referencing changed files?
    - PR description mentioning changed behavior?
-   - Related files with similar patterns?
-   - Other files in same directory?
+   - Related files with similar patterns? Other files in same directory?
+   - Changed code → docs/tests/configs; changed config → code/scripts referencing it; removed tool → all repo-wide references; changed URL → grep all files.
 
 4. **Quality Gates (scope-dependent):**
 
@@ -366,15 +272,15 @@ Confirmed: proceeding with [task] despite [blocker].
    - `npm run test:visual`: home page, blog archive, and archives page snapshots fail with small height differences (a few px to ~60px) because the new post changes listing-page length across viewports. Update baselines with `npm run test:visual:baseline` (ask first).
    - If OTHER tests fail, or visual diffs appear on pages unrelated to listings (individual posts, standalone pages), those ARE real and need investigation.
 
-5. **Never commit without verification**
+5. **Never commit without verification.** Before committing, report a one-line summary of what you searched and what you fixed.
 
-## Text Processing, Validation, Performance Rules
+## Coding Rules
 
-**Text parsing/strings:** Use exclusive range end (`pos < range.end`). Account for newlines in offsets (running offset, not `join('\n').length`). Never `.replace(substring, '')` on content that may repeat — use position ranges, slice, rebuild. Always `.trim()` before exact comparison (CRLF vs LF). Handle malformed input (unclosed blocks → extend range to `content.length`). Throw on missing expected resources; don't silently return empty.
+**Security/validation:** Use blocklists for dangerous protocols, not allowlists (allowlists block valid relative URLs). Apply `.trim().min(1).optional()` to all text fields.
 
-**Data validation:** Apply `.trim().min(1).optional()` to all text fields. Distinguish on-page vs metadata contexts. Use blocklists for dangerous protocols, not allowlists (allowlists block valid relative URLs).
+**Error handling:** Throw on missing expected resources; don't silently return empty.
 
-**Web performance:** `sizes` attribute must match actual container width, not viewport. Always include `width`/`height` on images (including SVGs) for CLS prevention.
+**Web performance:** Always include `width`/`height` on images (including SVGs) for CLS prevention. `sizes` attribute must match actual container width, not viewport.
 
 ## Dependency/Tool Change Protocol
 
@@ -387,23 +293,12 @@ When removing, replacing, or consolidating tools/dependencies:
 
 Example: replacing `broken-link-checker` with `htmltest` required updating `docs/link-checking.md`, `docs/index.md`, `README.md`, and searching for "broken-link-checker" and "linkwatch".
 
-## Pre-Commit Verification Protocol
-
-Before any commit that changes code/config:
-
-1. **Search for all instances** of the pattern being changed across `src/`, `scripts/`, `tests/`, `public/` — fix every occurrence, not just the reported one.
-2. **Check documentation** (`docs/`, `README.md`) for references to the changed files/concepts and update them.
-3. **Check interacting systems**: changed code → docs/tests/configs; changed config → code/scripts referencing it; removed tool → all repo-wide references; changed URL → grep all files.
-
-Report a one-line summary of what you searched and what you fixed before committing. No commit without it.
-
 ## Review Response Protocol
 
 When addressing review comments:
 
 1. **Architecture-problem pattern**: if you're in 10+ rounds of similar fixes, environment-specific drift (local vs staging vs prod), or repeatedly-drifting docs — STOP. The root is scattered config/architecture, not individual lines. Read config files, propose an abstraction layer (centralized registry, auto-generated docs, validation script) first, then address individual fixes.
-2. **Fix the pattern, not the line**: a comment on one case means find ALL instances of the same issue class and fix together.
-3. Run the Pre-Commit Verification Protocol above before committing.
+2. Run the Verification Protocol before committing.
 
 ## Communication Style
 - Provide clear, numbered steps for complex tasks
@@ -428,21 +323,7 @@ When instructions appear to conflict:
 4. **User authority:** User explicit instructions override general written rules — approval gates are satisfied by explicit per-action user instruction (which is the override mechanism, not a bypass)
 5. **Scope sensitivity:** Some rules are scope-dependent (e.g., quality gates for code vs docs)
 
-**Approval gates are hard stops, not tradeoffs.**
-- Do not let autonomy, bias-to-action, or end-to-end completion override an approval requirement.
-- Re-check authorization immediately before each gated action.
-- Missing approval means do not execute the action. (Exception: steps implied by an explicitly requested workflow are pre-approved — see workflow exception above.)
-
----
-
-# Project-Specific Guidelines
-
-# Extended Instructions
-
-For detailed workflows, see:
-- Complex workflows → Use custom skills in `.claude/skills/`
-- Specific tasks → Use slash commands in `.claude/commands/`
-- Automation → Use hooks in `.claude/hooks/`
+**Approval gates are hard stops.** Autonomy/autopilot mode does not override them. Re-check before each gated action. (Exception: steps implied by an explicitly requested workflow are pre-approved — see workflow exception above.)
 
 ---
 
@@ -505,4 +386,4 @@ The header date stamp tells the reader "this post was revised"; the inline marke
 - `/review` - Review draft for logic and flow (no rewriting)
 - `/factcheck` - Verify claims with web search and provide sources
 
-<!-- Keep total CLAUDE.md under 550 lines -->
+<!-- Keep total CLAUDE.md under 400 lines -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,4 +181,4 @@ When making content edits to a previously-published post, apply BOTH:
 - `/review` - Review draft for logic and flow (no rewriting)
 - `/factcheck` - Verify claims with web search and provide sources
 
-<!-- Keep total CLAUDE.md under 200 lines -->
+<!-- Keep total CLAUDE.md under 190 lines -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Three branches (never delete): `develop` → `staging` → `main`. All changes v
 - develop→staging: `git fetch origin && git checkout develop && git merge --ff-only origin/staging && git push origin develop`
 - staging→main: same for staging, then repeat develop against staging
 
-**If `--ff-only` fails:** `git log --oneline HEAD..origin/<branch>` to diagnose, then `git merge origin/<branch> --no-edit && git push`.
+**If `--ff-only` fails:** `git log --oneline HEAD..origin/<branch>` (what origin has, not you) and `git log --oneline origin/<branch>..HEAD` (what you have, not origin) to diagnose divergence, then `git merge origin/<branch> --no-edit && git push`.
 
 PR review fixes go to the **PR's HEAD branch**, not develop. "Update X" means edit the file — does not imply commit.
 
@@ -90,7 +90,7 @@ After any code change:
 
 1. **Search ALL instances** — `grep -rn "pattern" src/ scripts/ tests/ public/` before and after; must reach zero results.
 2. **Check docs and interacting systems** — read implementation first, not docs. Verify docs match code. Changed code → check docs/tests/configs; removed tool → grep all files.
-3. **Quality gates before push** — `npm run build && npm run check:links && npm run test:visual` (all must pass). New blog post exceptions: canonical URL 404 (resolves on deploy) and listing-page height diffs are expected (update baselines with `npm run test:visual:baseline` — ask first); other failures are real.
+3. **Quality gates before push** — `npm run build && npm run check:links && npm run test:visual` (all must pass). New blog post exceptions: canonical URL 404 (resolves on deploy) and listing-page height diffs are expected (update baselines with `npm run test:visual:baseline` — ask first); other failures are real. **Docs-only changes** (docs/, README.md): build required; link check and visual optional for trivial edits.
 4. Before committing, report a one-line summary of what you searched and what you fixed.
 
 ## Coding Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,232 +47,51 @@ If my instruction is unclear, ask what I want. Don't assume.
 
 ---
 
-# Token Optimization Rules
-
-## Context Management
-- Ask me before reading files >500 lines
-- Read only files directly relevant to current task
-- Use grep/search before reading entire files
-- Summarize findings concisely
-
 ## Development Philosophy
+- **MVP Features** (UI, content, blog posts): simple, hardcode defaults, don't over-engineer.
+- **Infrastructure** (scripts, CI/CD, config): production-grade, configurable, proper error handling, CI/CD-compatible.
 
-### Code Categories
-**MVP Features** (UI, content, blog posts):
-- Simple solutions, iterate fast
-- Hardcode reasonable defaults
-- Don't over-engineer
+## Configuration
 
-**Infrastructure** (scripts, build, CI/CD, tooling, **configuration**):
-- Production-grade from start
-- Configurable (not hardcoded)
-- Proper error handling required (code-level errors; operational failures: see Blocker Resolution Protocol)
-- Must work in CI/CD environments
-- Resource cleanup (try/finally for processes/connections)
-- **Configuration files** (astro.config.ts, src/config/index.ts, env schemas):
-  - Must be centralized and validated
-  - Abstraction justified when preventing drift/repeated fixes
-  - Examples: Config registry, validation scripts, auto-generated docs
-
-### General Principles
-- Start with simplest solution that works
-- Don't add unnecessary abstractions **unless infrastructure requires it**
-- Skip edge case handling unless critical
-- Ask: "Would copying be easier than generalizing?" If yes, copy.
-- **Exception:** Infrastructure abstractions (config registry, validation) justified when preventing repeated manual fixes
-
-## Configuration Abstraction Layer
-
-**Single Source of Truth:** `config/registry.mjs`
-
-`npm run config:validate` enforces consistency across workflows, env schema, code, deployment, docs, and hardcoded fallbacks. Runs in all deployment workflows.
-
-**When to update configuration:**
-1. Change value in `config/registry.mjs`
-2. Run `npm run config:generate && npm run config:validate`
-3. Update workflows if needed
-4. Commit all changes together
-
-### Common Scenarios
-
-- **Adding a new env var:** add to `astro.config.ts` env schema + `config/registry.mjs` + affected workflows, then run `npm run config:generate && npm run config:validate`.
-- **Changing a URL:** update in `config/registry.mjs` + workflows + `src/config/index.ts` fallbacks; validation will catch mismatches.
+**Single Source of Truth:** `config/registry.mjs`. After any config change: `npm run config:generate && npm run config:validate`, update workflows, commit together.
+- **New env var:** add to `astro.config.ts` env schema + registry + affected workflows, then validate.
+- **URL change:** update registry + workflows + `src/config/index.ts` fallbacks; validate.
 
 ## Git Workflow
 
-### Branch Structure
-- **Three long-lived branches** (never delete): `develop` → `staging` → `main`
-- All changes flow: develop → staging → main via pull requests
+Three branches (never delete): `develop` → `staging` → `main`. All changes via pull requests.
 
-### Before Making Changes
+**Before changes:** Docker must be running (push hooks require it). Sync: `git pull origin develop`.
 
-**⚠️ CRITICAL: Verify Docker is running FIRST**
+**After PR merges:** fast-forward source branch to include target's merge commit:
+- develop→staging: `git fetch origin && git checkout develop && git merge --ff-only origin/staging && git push origin develop`
+- staging→main: same for staging, then repeat develop against staging
 
-Pre-push hooks require Docker for build tests. Pushing will fail if Docker daemon is not running.
+**If `--ff-only` fails:** `git log --oneline HEAD..origin/<branch>` to diagnose, then `git merge origin/<branch> --no-edit && git push`.
 
-```bash
-# Verify Docker is running
-docker ps
-# If error: "Cannot connect to the Docker daemon" → start Docker Desktop first
-```
-
-**ALWAYS sync local branches with origin first:**
-```bash
-# Sync the branch you're working on
-git checkout develop
-git pull origin develop
-```
-(On conflicts or failure, see Blocker Resolution Protocol)
-
-**To sync all branches:**
-```bash
-git checkout main && git pull origin main
-git checkout staging && git pull origin staging
-git checkout develop && git pull origin develop
-```
-(On conflicts or failure, see Blocker Resolution Protocol)
-
-### Making Changes
-1. Ensure you're on `develop` branch and synced
-2. Make your changes
-3. Commit with descriptive messages **only if explicitly asked to commit**
-4. Push to origin: `git push origin develop` **only if explicitly asked to push** (on failure, see Blocker Resolution Protocol)
-5. Create PR: `develop` → `staging`
-6. After staging approval, create PR: `staging` → `main`
-
-### After PR Merges
-
-Sync source branch to include the merge commit added to the target branch. Docker must be running (see "Before Making Changes").
-
-**After develop → staging merges:**
-```bash
-git fetch origin
-git checkout develop
-git pull --ff-only origin develop
-git merge --ff-only origin/staging
-git push origin develop
-```
-
-**After staging → main merges:**
-```bash
-git fetch origin
-git checkout staging
-git pull --ff-only origin staging
-git merge --ff-only origin/main
-git push origin staging
-
-# Then sync develop with the updated staging
-git checkout develop
-git pull --ff-only origin develop
-git merge --ff-only origin/staging
-git push origin develop
-```
-
-**If `--ff-only` fails:** branches have diverged (shouldn't happen in normal gitflow). Diagnose with `git log --oneline HEAD..origin/<branch>`, then `git merge origin/<branch> --no-edit && git push`.
-
-### PR Review Fixes
-- Commit fixes to the **PR's HEAD branch**, not develop
-- Example: Comments on PR (staging→main) → fix on `staging` branch
-- If fixes were made on wrong branch, cherry-pick to correct branch (on failure, see Blocker Resolution Protocol)
-
-### No Out-of-Scope Commits
-- "Update X" means edit the file — it does not imply commit. Approval gates apply per-change.
+PR review fixes go to the **PR's HEAD branch**, not develop. "Update X" means edit the file — does not imply commit.
 
 ## Blocker Resolution Protocol
 
-**DEFAULT: When operations fail (exit code != 0 or explicit error):**
+When any operation fails (exit code != 0): **STOP**, report what failed + current state + error output, present options, wait for explicit direction.
 
-1. **STOP immediately** - Do not proceed with other work
-2. **Report the failure:**
-   - What failed (command, operation, step)
-   - Current state (unpushed commits, conflicts, partial completion)
-   - Error message/output
-3. **Present options** - Give user clear choices for resolution
-4. **Wait for explicit direction** - Do not assume, retry, or work around
+**Blockers:** git failures, non-zero exit codes, build/test failures, file operation errors.
+**Not blockers:** warnings, deprecation notices, advisory output.
 
-### What Counts as a Blocker
+**Never auto-retry.** Example: `Push failed: network timeout — commit ad88b33 local only. Retry / push manually / amend?`
 
-**STOP on these:**
-- Git operations fail (push, pull, fetch, merge returns conflicts)
-- Commands return exit code != 0
-- Build/test failures
-- File operations fail (permission denied, file not found when expected)
+On background task failure: report immediately, don't start new work until resolved.
 
-**Do NOT stop on these:**
-- Warnings (operation succeeds with warnings)
-- Deprecation notices
-- Successful operations with advisory output
-
-### Retry Logic
-
-**Never auto-retry.** Even for transient failures (network timeout), stop and ask. Example: `Push failed: network timeout — commit ad88b33 exists locally but not on origin. Retry / push manually / amend?`
-
-### Background Task Failures
-
-When notified of background task failure:
-1. Report immediately in next response
-2. Do not start NEW work until resolved
-3. Ongoing work can complete
-
-### User Override
-
-User can override by explicitly saying "continue anyway" or "ignore the error."
-
-Before proceeding, confirm understanding:
-```
-Confirmed: proceeding with [task] despite [blocker].
-[Specific consequence of proceeding].
-```
+User override: "continue anyway" or "ignore the error" — confirm: `Proceeding with [task] despite [blocker]. [Consequence].`
 
 ## Verification Protocol
 
-**After making ANY code change:**
+After any code change:
 
-1. **Search for ALL instances** before claiming "fixed"
-   ```bash
-   # Before fixing:
-   grep -rn "pattern" src/ scripts/ tests/ public/
-
-   # After fixing ALL instances:
-   grep -rn "pattern" src/ scripts/ tests/ public/  # MUST return zero results
-   ```
-
-2. **Verify documentation against source code:**
-   - **Read implementation first, not other docs**
-   - Every documentation claim → verify in actual code
-   - Example: Doc says "analytics load on remote URLs"
-     - ❌ Don't trust the doc
-     - ✅ Read src/components/GoogleAnalytics.astro to verify actual gating logic
-   - Config behavior claims → read astro.config.ts, src/config/index.ts
-   - Test behavior claims → read actual test files
-
-3. **Check side effects and interacting systems:**
-   - Documentation referencing changed files?
-   - PR description mentioning changed behavior?
-   - Related files with similar patterns? Other files in same directory?
-   - Changed code → docs/tests/configs; changed config → code/scripts referencing it; removed tool → all repo-wide references; changed URL → grep all files.
-
-4. **Quality Gates (scope-dependent):**
-
-   **For code changes (src/, scripts/, config files):**
-   ```bash
-   npm run build           # MUST pass
-   npm run check:links     # MUST pass
-   npm run test:visual     # MUST pass
-   ```
-   All three MUST pass before git push. If any fail, see Blocker Resolution Protocol.
-
-   **For documentation-only changes (docs/, README.md):**
-   - Verification steps 1-3 required
-   - Quality gates optional if changes are trivial (typo fixes, wording)
-   - Use judgment: if doc change affects behavior understanding, run tests
-
-   **Expected failures when adding a new blog post (not real regressions):**
-   - `npm run check:links`: self-referential canonical URL (e.g. `https://kyle.skrinak.com/posts/<slug>/`) returns 404 because the post isn't deployed yet. Resolves automatically after deploy.
-   - `npm run test:visual`: home page, blog archive, and archives page snapshots fail with small height differences (a few px to ~60px) because the new post changes listing-page length across viewports. Update baselines with `npm run test:visual:baseline` (ask first).
-   - If OTHER tests fail, or visual diffs appear on pages unrelated to listings (individual posts, standalone pages), those ARE real and need investigation.
-
-5. **Never commit without verification.** Before committing, report a one-line summary of what you searched and what you fixed.
+1. **Search ALL instances** — `grep -rn "pattern" src/ scripts/ tests/ public/` before and after; must reach zero results.
+2. **Check docs and interacting systems** — read implementation first, not docs. Verify docs match code. Changed code → check docs/tests/configs; removed tool → grep all files.
+3. **Quality gates before push** — `npm run build && npm run check:links && npm run test:visual` (all must pass). New blog post exceptions: canonical URL 404 (resolves on deploy) and listing-page height diffs are expected; other failures are real.
+4. Before committing, report a one-line summary of what you searched and what you fixed.
 
 ## Coding Rules
 
@@ -282,28 +101,17 @@ Confirmed: proceeding with [task] despite [blocker].
 
 **Web performance:** Always include `width`/`height` on images (including SVGs) for CLS prevention. `sizes` attribute must match actual container width, not viewport.
 
-## Dependency/Tool Change Protocol
-
-When removing, replacing, or consolidating tools/dependencies:
-
-1. Grep `docs/`, `README.md`, and `tests/` for references to the old tool — update every reference (command examples, workflow docs, architecture descriptions, tech-stack lists). No orphans.
-2. For workflow changes: verify conditional logic. Common gotcha: `continue-on-error` + `if: failure()` won't fire as expected — capture exit codes explicitly.
-3. Test the docs you write — run the commands, don't assume; confirm `package.json` scripts match what docs claim.
-4. Delete obsolete code: scripts, config files, unused utilities. Grep `scripts/*.js` for orphans.
-
-Example: replacing `broken-link-checker` with `htmltest` required updating `docs/link-checking.md`, `docs/index.md`, `README.md`, and searching for "broken-link-checker" and "linkwatch".
-
 ## Review Response Protocol
 
-When addressing review comments:
+Fix the **pattern** (all instances of the same issue class), not just the one flagged line. When removing a tool, grep `docs/`, `README.md`, `tests/` for references and update every one. For workflow changes, verify conditional logic — `continue-on-error` + `if: failure()` won't fire as expected; capture exit codes explicitly. Run the Verification Protocol before committing.
 
-1. **Architecture-problem pattern**: if you're in 10+ rounds of similar fixes, environment-specific drift (local vs staging vs prod), or repeatedly-drifting docs — STOP. The root is scattered config/architecture, not individual lines. Read config files, propose an abstraction layer (centralized registry, auto-generated docs, validation script) first, then address individual fixes.
-2. Run the Verification Protocol before committing.
+If stuck in 10+ rounds of similar fixes or environment-specific drift: STOP. Propose a root-cause abstraction before addressing individual lines.
 
 ## Communication Style
 - Provide clear, numbered steps for complex tasks
 - State assumptions upfront
 - Ask clarifying questions before exploration
+- Ask before reading files >500 lines; read only files directly relevant to the current task
 - Summarize findings in <100 words when possible
 - Skip unnecessary engagement phrases ("You're right!", "Perfect!", "Good catch!")
 - No anthropomorphizing qualifiers ("Honestly…", "To be frank…", "I should mention…") — just state facts directly
@@ -323,16 +131,15 @@ When instructions appear to conflict:
 4. **User authority:** User explicit instructions override general written rules — approval gates are satisfied by explicit per-action user instruction (which is the override mechanism, not a bypass)
 5. **Scope sensitivity:** Some rules are scope-dependent (e.g., quality gates for code vs docs)
 
-**Approval gates are hard stops.** Autonomy/autopilot mode does not override them. Re-check before each gated action. (Exception: steps implied by an explicitly requested workflow are pre-approved — see workflow exception above.)
+**Approval gates are hard stops.** Bias-to-action, autonomy/autopilot mode, and end-to-end completion drive do not override them. Re-check before each gated action. Missing approval means do not execute. (Exception: steps implied by an explicitly requested workflow are pre-approved — see workflow exception above.)
 
 ---
 
 # Blog Writing Rules
 
 ## Filename Convention
-- Blog post files in `src/content/blog/` MUST be lowercase-kebab-case (e.g., `2026-04-19-sculpting-down.md`, not `2026-04-19-Sculpting-Down.md`)
-- Format: `YYYY-MM-DD-slug.md` where `slug` is lowercase words joined by hyphens
-- **Why:** `getPath()` (`src/utils/getPath.ts`) uses `post.id` directly for the URL slug with no lowercasing. Keeping filenames lowercase-kebab-case ensures the filename matches the generated URL with no dependency on any implicit normalization elsewhere. It also avoids case-sensitivity bugs that macOS (case-insensitive APFS) hides but Linux CI/deploy targets surface as 404s.
+- Blog post files: `src/content/blog/YYYY-MM-DD-lowercase-kebab-slug.md`
+- `getPath()` uses `post.id` directly (no lowercasing) — wrong case causes 404s on Linux CI even if macOS hides it.
 
 ## Voice & Prose
 - **DO NOT** rewrite my narrative voice or prose
@@ -340,10 +147,7 @@ When instructions appear to conflict:
 - Your job is to identify problems, not fix my voice
 
 ## Feedback Approach
-- Flag logic gaps and weak transitions - do not silently fix them
-- Point out issues and explain WHY they're problems
-- Leave the actual fixing to me
-- Be specific about locations (paragraph numbers, sections)
+Flag logic gaps and weak transitions — explain WHY they're problems. Leave fixing to me. Be specific about locations (paragraph numbers, sections).
 
 ## What You Can Edit Directly
 - Grammar corrections (typos, punctuation, subject-verb agreement)
@@ -351,39 +155,30 @@ When instructions appear to conflict:
 - Only when explicitly asked: "apply grammar corrections"
 
 ## Factual Claims
-- Any factual claims must be sourced when verified
-- Flag anything unverifiable - don't guess or assume
-- Prefer primary sources over secondary
-- Note when information might be time-sensitive
+Source verifiable claims; flag anything unverifiable. Prefer primary sources; note time-sensitive information.
 
 ## Review Structure
-When reviewing drafts, follow this priority:
-1. Logic and argument flow first
-2. Structure and transitions second
-3. Clarity and precision third
-4. Grammar and polish last
+1. Logic and argument flow
+2. Structure and transitions
+3. Clarity and precision
+4. Grammar and polish
 
 ## Post Revisions
 
 When making content edits to a previously-published post, apply BOTH:
 
-1. **Frontmatter** — add `updatedDate: YYYY-MM-DDTHH:MM:SS.000Z` (today's date, UTC).
-   - Drives the "Revised on:" label in the post header (`src/components/Datetime.astro`)
-   - Changes the item's RSS `pubDate` to the update date (via `updatedDate ?? pubDate` in `src/pages/rss.xml.ts`); most RSS readers sort by this field, so the post re-surfaces as recently updated. XML item order in the feed is unchanged (driven by `getSortedPosts`, which sorts by `pubDate` only)
-   - Does **NOT** affect post sort order — original `pubDate` always drives ordering (`src/utils/getSortedPosts.ts`)
+1. **Frontmatter** — add `updatedDate: YYYY-MM-DDTHH:MM:SS.000Z` (today's date, UTC). Drives the "Revised on:" label and RSS `pubDate` update; does NOT affect sort order (original `pubDate` controls ordering).
 
-2. **Inline marker at each change point** — plain italic line directly after the affected paragraph or block:
+2. **Inline marker at each change point** — plain italic line directly after the affected paragraph:
    ```markdown
    *Revised YYYY-MM-DD: brief description of what changed.*
    ```
 
-The header date stamp tells the reader "this post was revised"; the inline marker tells them "and here is exactly what changed." Do not also add an end-of-post summary — it duplicates the header.
-
-**Markdown caveat:** this Astro setup does NOT support Kramdown attribute syntax (`{: .class}`). Use plain markdown italic, not class-based styling.
+**Note:** This Astro setup does NOT support Kramdown attribute syntax (`{: .class}`). Use plain markdown italic.
 
 ## Available Commands
 - `/outline` - Generate structured outline from topic or notes
 - `/review` - Review draft for logic and flow (no rewriting)
 - `/factcheck` - Verify claims with web search and provide sources
 
-<!-- Keep total CLAUDE.md under 400 lines -->
+<!-- Keep total CLAUDE.md under 200 lines -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ User override: "continue anyway" or "ignore the error" — confirm: `Proceeding 
 
 After any code change:
 
-1. **Search ALL instances** — `grep -rn "pattern" src/ scripts/ tests/ public/` before and after; must reach zero results.
+1. **Search ALL instances** — `grep -rn "pattern" src/ scripts/ tests/ public/ config/` before and after; must reach zero results.
 2. **Check docs and interacting systems** — read implementation first, not docs. Verify docs match code. Changed code → check docs/tests/configs; removed tool → grep all files.
 3. **Quality gates before push** — `npm run build && npm run check:links && npm run test:visual` (all must pass). New blog post exceptions: canonical URL 404 (resolves on deploy) and listing-page height diffs are expected (update baselines with `npm run test:visual:baseline` — ask first); other failures are real. **Docs-only changes** (docs/, README.md): build required; link check and visual optional for trivial edits.
 4. Before committing, report a one-line summary of what you searched and what you fixed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,8 @@ After any code change:
 
 **Error handling:** Throw on missing expected resources; don't silently return empty.
 
+**Text parsing:** Use exclusive range end (`pos < range.end`). Track running offsets (not `join('\n').length`). Never `.replace(substring, '')` on repeating content — use position ranges. Always `.trim()` before exact comparison (CRLF vs LF). Handle malformed input: unclosed blocks → extend range to `content.length`.
+
 **Web performance:** Always include `width`/`height` on images (including SVGs) for CLS prevention. `sizes` attribute must match actual container width, not viewport.
 
 ## Review Response Protocol
@@ -181,4 +183,4 @@ When making content edits to a previously-published post, apply BOTH:
 - `/review` - Review draft for logic and flow (no rewriting)
 - `/factcheck` - Verify claims with web search and provide sources
 
-<!-- Keep total CLAUDE.md under 190 lines -->
+<!-- Keep total CLAUDE.md under 200 lines -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ After any code change:
 
 1. **Search ALL instances** — `grep -rn "pattern" src/ scripts/ tests/ public/` before and after; must reach zero results.
 2. **Check docs and interacting systems** — read implementation first, not docs. Verify docs match code. Changed code → check docs/tests/configs; removed tool → grep all files.
-3. **Quality gates before push** — `npm run build && npm run check:links && npm run test:visual` (all must pass). New blog post exceptions: canonical URL 404 (resolves on deploy) and listing-page height diffs are expected; other failures are real.
+3. **Quality gates before push** — `npm run build && npm run check:links && npm run test:visual` (all must pass). New blog post exceptions: canonical URL 404 (resolves on deploy) and listing-page height diffs are expected (update baselines with `npm run test:visual:baseline` — ask first); other failures are real.
 4. Before committing, report a one-line summary of what you searched and what you fixed.
 
 ## Coding Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ If my instruction is unclear, ask what I want. Don't assume.
 
 Three branches (never delete): `develop` → `staging` → `main`. All changes via pull requests.
 
-**Before changes:** Docker must be running (push hooks require it). Sync: `git pull origin develop`.
+**Before changes:** Docker must be running (push hooks require it). Sync: `git pull --ff-only origin develop` (fails fast on divergence; diagnose per `--ff-only` block below).
 
 **After PR merges:** fast-forward source branch to include target's merge commit:
 - develop→staging: `git fetch origin && git checkout develop && git pull --ff-only origin develop && git merge --ff-only origin/staging && git push origin develop`


### PR DESCRIPTION
## Summary

Two related changes to the AI instruction set and tooling:

### 1. Trim CLAUDE.md (389 → 186 lines)
Aggressively removed redundancy and operational prose while preserving every safety-critical behavioral rule. All 14 required rules verified present:
- Approval gates (`"fix" ≠ "commit" ≠ "push"`, fail-closed)
- Blocker Resolution Protocol
- Verification Protocol + quality gates
- Git workflow (Docker check, `--ff-only`, PR branch rule)
- Post-revision markers (`updatedDate`, `*Revised YYYY-MM-DD:*`)
- `continue-on-error` CI gotcha
- `bias-to-action` guard
- Ask before reading files >500 lines

Under the 200-line budget at 186 lines.

### 2. Add `.claude/agents/github-code-reviewer.md`
New custom agent for pre-GitHub code reviews. Features:
- Project context baked in (repo, stack, conventions, forbidden dirs)
- Role boundary: reports only, never edits
- 6-step review workflow with `| cat` on all git commands (pager-hang safe)
- Step 6: CLAUDE.md required-rules checklist with Critical severity for missing safety rules
- Self-contained — does not inherit CLAUDE.md

## Copilot Review Fixes (commit `813d144`)

Addressed two unresolved Copilot review comments:

1. **CLAUDE.md:64** — Initial sync changed from `git pull origin develop` to `git pull --ff-only origin develop` so divergence fails fast, matching the post-merge sync block (line 67) and the `--ff-only` diagnosis block (line 70).
2. **`.claude/agents/github-code-reviewer.md`** — Resolved the contradiction between the forbidden-paths list and "read the full diff" workflow step. Added a clarification that the forbidden-paths list governs *unsolicited* reads (a PR diff IS the "specific request" for in-scope changes), and excluded `package-lock.json` from the diff command as noise (review `package.json` instead).

## Commits (12)
- `813d144` Address PR #140 Copilot review: ff-only sync and diff/forbidden-paths contradiction
- `37e2498` Fix three review items: grep config/, package-lock.json, docs/ wording
- `bb863d3` Restore git pull --ff-only origin develop to post-merge sync workflow
- `ae59e29` Restore text-parsing rules, fix YAML name order, reset line budget to 200
- `be2127d` Fix three more review items: step 6 severity, YAML block scalar, line budget
- `631c41d` Fix three review items: docs gate, ff-only diagnosis, large-diff fallback
- `7e46692` Add minor review items: test:visual:baseline recovery and CLAUDE.md compliance check
- `a421026` Fix git log missing | cat in review workflow step 1
- `362ab25` Fix github-code-reviewer agent: pipe git status, expand forbidden dirs
- `1080330` Trim CLAUDE.md to ~185 lines; improve github-code-reviewer agent
- `54b002a` Trim CLAUDE.md: remove redundancy, restore coding rules
- `b369076` Add github-code-reviewer custom agent

## Testing
Reviewed via `github-code-reviewer` agent through 6+ iterative self-review cycles. All Copilot comments addressed. Build verified after final fixes. All 14 required rules verified present.