### PR TITLE
Anchor fun-at-scale hero image to top to keep heading visible

### DIFF
--- a/src/content/blog/2026-02-02-fun-at-scale.md
+++ b/src/content/blog/2026-02-02-fun-at-scale.md
@@ -3,6 +3,7 @@ title: "Fun at Scale"
 pubDate: 2026-02-02T00:00:00.000Z
 description: "How AI tools transformed my blog from languishing Jekyll infrastructure to a modern Astro site—and made computing enjoyable again"
 image: ../../assets/images/fun-at-scale.png
+imagePosition: top
 alt: "Good, Better, Best - progression diagram"
 tags:
   - ai


### PR DESCRIPTION
Follow-up to PR #143. After the SVG→PNG conversion, the post hero on `2026-02-02-fun-at-scale.md` was rendering with `object-fit: cover` + center crop, clipping the heading text at the top of the graphic.

## Change
- `src/content/blog/2026-02-02-fun-at-scale.md` — added `imagePosition: top` to the frontmatter.

## Mechanics
- `imagePosition` is an existing content-schema enum (`src/content.config.ts:19`); `top` is a valid value.
- `src/layouts/PostDetails.astro:147-148` passes the value through to Astro's `Image` as `position`, which sets `object-position`. Combined with `fit="cover"`, this anchors the crop to the bottom edge and keeps the top of the image fully visible.
- Precedent: `2026-04-29-what-forty-years-of-displacement-...md` already uses `imagePosition: "bottom"` for the same kind of fix.

## Verification
- Locally verified via `npm run dev` — text in the hero graphic is now fully visible.

## Test plan
- [ ] CI visual regression check