### PR TITLE
Anchor fun-at-scale hero image to top to keep heading visible

### DIFF
--- a/src/content/blog/2026-02-02-fun-at-scale.md
+++ b/src/content/blog/2026-02-02-fun-at-scale.md
@@ -3,6 +3,7 @@ title: "Fun at Scale"
 pubDate: 2026-02-02T00:00:00.000Z
 description: "How AI tools transformed my blog from languishing Jekyll infrastructure to a modern Astro site—and made computing enjoyable again"
 image: ../../assets/images/fun-at-scale.png
+imagePosition: top
 alt: "Good, Better, Best - progression diagram"
 tags:
   - ai


### PR DESCRIPTION
Promotes the hero-crop fix from PR #144 (develop → staging, merged in `af95185`).

## Change
- `src/content/blog/2026-02-02-fun-at-scale.md` — added `imagePosition: top` to the frontmatter.

## Why
After the SVG→PNG conversion in PR #143, the post hero was rendering with `object-fit: cover` + default center crop, clipping the heading text. `imagePosition: top` anchors the crop to the bottom edge so the top of the graphic stays visible.

## Verification
- PR #144 (develop→staging) merged green.
- Locally verified the rendered hero in `npm run dev`.

## Test plan
- [ ] CI visual regression check