### PR TITLE
refactor: unify BASE_URL joining via linkWithBase() in Layout.astro

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,7 +25,7 @@ export const SITE = {
     text: "Edit on GitHub",
     url: "https://github.com/kyleskrinak/kyleskrinak.github.io/edit/main/",
   },
-  defaultOgImage: "og.png", // root-relative filename; resolved via `${BASE_URL}${defaultOgImage}` in Layout.astro. Built by src/pages/og.png.ts.
+  defaultOgImage: "og.png", // root-relative filename; resolved via linkWithBase() in Layout.astro. Built by src/pages/og.png.ts.
   dynamicOgImage: true, // when true, posts render Satori per-post OG images instead of falling back to defaultOgImage
   dir: "ltr", // "rtl" | "auto"
   lang: "en", // html lang code. Set this empty and default will be "en"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,6 +17,7 @@ type Props = {
   author?: string;
   profile?: string;
   description?: string;
+  /** Must be root-relative (e.g. `/og.png`) or absolute — bare relative paths produce wrong URLs via new URL(). */
   ogImage?: string;
   canonicalURL?: string;
   pubDate?: Date;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ import {
 } from "astro:env/client";
 import { SITE } from "@/config";
 import { canonicalizePathname } from "@/utils/canonicalizePathname";
+import { linkWithBase } from "@/utils/linkWithBase";
 import GoogleAnalytics from "@/components/GoogleAnalytics.astro";
 import "@/styles/global.css";
 
@@ -34,7 +35,7 @@ const {
   author = SITE.author,
   profile = SITE.profile,
   description = SITE.desc,
-  ogImage = `${import.meta.env.BASE_URL}${SITE.defaultOgImage}`,
+  ogImage = linkWithBase(SITE.defaultOgImage),
   canonicalURL = new URL(pathname, Astro.site).href,
   pubDate,
   updatedDate,
@@ -75,10 +76,10 @@ const structuredData = {
     <meta name="viewport" content="width=device-width" />
 
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href={`${import.meta.env.BASE_URL}favicon.ico`} />
-    <link rel="icon" type="image/png" sizes="96x96" href={`${import.meta.env.BASE_URL}favicon-96x96.png`} />
-    <link rel="apple-touch-icon" href={`${import.meta.env.BASE_URL}apple-touch-icon.png`} />
-    <link rel="manifest" href={`${import.meta.env.BASE_URL}site.webmanifest`} />
+    <link rel="icon" type="image/x-icon" href={linkWithBase("favicon.ico")} />
+    <link rel="icon" type="image/png" sizes="96x96" href={linkWithBase("favicon-96x96.png")} />
+    <link rel="apple-touch-icon" href={linkWithBase("apple-touch-icon.png")} />
+    <link rel="manifest" href={linkWithBase("site.webmanifest")} />
 
     {/* Canonical link: tells search engines and tools where the "true" content lives.
         Can point to this page or to an external canonical URL via the canonicalURL prop. */}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,6 +43,8 @@ const {
   noindex = false,
 } = Astro.props;
 
+// ogImage must be root-relative (e.g. /og.png) or absolute — new URL() resolves
+// root-relative paths against the origin, ignoring the current page path.
 const socialImageURL = new URL(ogImage, Astro.url);
 
 const deployEnv = PUBLIC_DEPLOY_ENV ?? "production";

--- a/src/utils/linkWithBase.ts
+++ b/src/utils/linkWithBase.ts
@@ -6,6 +6,7 @@
 export function linkWithBase(path: string): string {
   const base = import.meta.env.BASE_URL || '/';
   if (path.startsWith('http')) return path; // external links
+  if (path.startsWith('//')) return path; // protocol-relative URLs
   if (path.startsWith('#')) return path; // anchor links
 
   // Remove leading slash to avoid double slashes


### PR DESCRIPTION
## Summary

Replaces all manual `${import.meta.env.BASE_URL}path` template-literal concatenations in `Layout.astro` with the `linkWithBase()` utility, ensuring consistent base-path handling across OG image and favicon links.

## Changes

- `src/layouts/Layout.astro` — replace 5 template-literal BASE_URL joins with `linkWithBase()`; add `ogImage` prop JSDoc documenting root-relative/absolute requirement
- `src/utils/linkWithBase.ts` — add protocol-relative URL guard (`//`); guard chain: `http` → `//` → `#` → normalize-and-prefix
- `src/config/index.ts` — update stale `defaultOgImage` comment to reference `linkWithBase()`

## Why

The old string concatenation (`${BASE_URL}favicon.ico`) was fragile: with `BASE_URL=""` it produced a bare relative path rather than a root-relative one. `linkWithBase()` normalizes this correctly for all BASE_URL values.

## Adversarial review

All 7 adversarial angles verified clean (null guard, ogImage prop bypass, `new URL()` invariant, guard ordering, favicon behavioral equivalence). No critical or major findings. Two minor documentation gaps fixed inline.