### PR TITLE
chore(deps): batch dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7296,9 +7296,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7742,9 +7742,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -7761,7 +7761,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4827,9 +4827,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.7.tgz",
-      "integrity": "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -4838,7 +4838,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -10221,6 +10222,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2346,16 +2346,16 @@
       }
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
     "node_modules/@tailwindcss/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,28 +1948,28 @@
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.1.0.tgz",
-      "integrity": "sha512-YbuOcAA3kwqKDU9YSt00dtFLrY5lBXjKU3dWaMATyEyPSqBm9Jqblk/uVICxz7lcjwAHzYaEvIiMWX3mTpogkA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-pKrYVNUr1oPjJvs76gkPPirDySx3GKG9O88P2Y3AQ+7AjSFws9Y+Ry/Q/6Yg6QpyigzjdQ6H5JAMNAvLXZ63dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.1.0",
-        "@shikijs/types": "4.1.0"
+        "@shikijs/core": "4.2.0",
+        "@shikijs/types": "4.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
-      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.1.0",
-        "@shikijs/types": "4.1.0",
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -1979,13 +1979,13 @@
       }
     },
     "node_modules/@shikijs/transformers/node_modules/@shikijs/primitive": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
-      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -1994,9 +1994,9 @@
       }
     },
     "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4106,9 +4106,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "fast-xml-parser": "5.7.0",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.6",
-    "postcss": "8.5.10"
+    "postcss": "8.5.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.16.0",
   "scripts": {
     "dev": "astro dev",
     "build": "node scripts/check-image-conventions.mjs --all && astro build && pagefind --site dist && cp -r dist/_pagefind public/",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "overrides": {
     "devalue": "5.8.1",
     "fast-uri": "3.1.2",
-    "fast-xml-builder": "1.1.7",
+    "fast-xml-builder": "1.2.0",
     "fast-xml-parser": "5.7.0",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.6",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "description": "Routine bumps grouped by ecosystem (minor + patch only). Major bumps fall through to Renovate's default and open as individual PRs for explicit review. The 'typescript' group is patch-only on purpose — TS minor releases can ship subtle type-system changes, so minor TS bumps open as individual PRs too. The 'utilities' group's `lodash.*` glob matches per-method packages like `lodash.kebabcase` but NOT the bare `lodash` package (no dot); if `lodash` is ever added, either extend matchPackageNames or expect it to open as an individual PR. baseBranches: develop combined with useBaseBranchConfig: merge so Renovate reads this config from develop in addition to main (the GitHub default branch). Security PRs (vulnerabilityAlerts) target develop too with minimumReleaseAge: 0 — they still flow develop → staging → main; for critical CVEs the human operator fast-tracks promotion manually. This preserves the multi-stage gate that the rest of the deploy workflow assumes. enabledManagers is restricted to npm on purpose: the Dockerfile base image and the SHA-pinned GitHub Actions are managed manually as part of the supply-chain posture, so Renovate must not silently open PRs against them.",
   "extends": ["config:recommended"],
   "enabledManagers": ["npm"],
-  "baseBranches": ["develop"],
+  "baseBranchPatterns": [
+    "develop"
+  ],
   "useBaseBranchConfig": "merge",
   "schedule": ["before 9am on Monday"],
   "timezone": "America/New_York",


### PR DESCRIPTION
## Summary
Batch promotion of dependency updates from develop to staging:

### Merged Updates
- `postcss`: 8.5.10 → 8.5.15 (patch - bug fixes)
- `tailwind` (@tailwindcss/typography): 0.5.19 → 0.5.20 (patch)
- `utilities` (dayjs): 1.11.20 → 1.11.21 (patch)
- `fast-xml-builder`: 1.1.7 → 1.2.0 (minor - RSS feed)
- `markdown` (@shikijs/transformers): 4.1.0 → 4.2.0 (minor - syntax highlighting)
- `npm`: 11.12.1 → 11.16.0 (minor)

All updates passed local quality gates (build, link check, visual tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)