### PR TITLE
chore(deps): bump fast-xml-parser to staging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4843,9 +4843,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -4855,9 +4855,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8724,9 +8725,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "devalue": "5.8.1",
     "fast-uri": "3.1.2",
     "fast-xml-builder": "1.2.0",
-    "fast-xml-parser": "5.7.0",
+    "fast-xml-parser": "5.8.0",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.6",
     "postcss": "8.5.15"


### PR DESCRIPTION
## Summary
Promote fast-xml-parser update from develop to staging:

- `fast-xml-parser`: 5.7.0 → 5.8.0 (minor - RSS feed dependency)

Passed local quality gates (build, link check, visual tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)