### PR TITLE
chore(deps): bump fast-uri 3.1.2 → 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4789,9 +4789,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.0.0.tgz",
+      "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "overrides": {
     "devalue": "5.8.1",
-    "fast-uri": "3.1.2",
+    "fast-uri": "4.0.0",
     "fast-xml-builder": "1.2.0",
     "fast-xml-parser": "5.9.0",
     "flatted": "3.4.2",


### PR DESCRIPTION
## Summary

- `fast-uri` 3.1.2 → 4.0.0 (pinned transitive dep)
- Breaking change is TypeScript type removal (deprecated types) — no runtime impact since fast-uri is not directly imported by this project
- Includes an escape bug fix

## Test plan

- [x] Build passes
- [x] Link check passes
- [x] Visual regression 36/36 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)