### PR TITLE
tsconfig: drop deprecated baseUrl; fix pagefind exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist", "public/pagefind"],
+  "exclude": ["dist", "public/_pagefind"],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
Promotes `staging` to `main` (production). Mirrors #227, already merged to staging. Single commit (`7133cb6`).

## Change
- Remove `baseUrl: "."` from `tsconfig.json` — deprecated in TypeScript 6.0, removed in 7.0. The `@/*` → `./src/*` path mappings are relative and resolve identically without it; Astro reads `paths` directly for its Vite aliases.
- Correct `exclude` to the built Pagefind output dir (`public/_pagefind`), matching the actual directory and the eslint ignore.

No runtime/output change — config + types only.

## Verification
- `astro check` ✅ 0 errors, 0 warnings
- `npm run build` ✅
- `npm run test:unit` ✅ 39/39
- `npm test` (Playwright) ✅ 22 passed, 0 failed, 17 env-gated skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)