### PR TITLE
feat(archive): downloadable PDF books — promote to production

### DIFF
--- a/.github/actions/ensure-archive-pdfs/action.yml
+++ b/.github/actions/ensure-archive-pdfs/action.yml
@@ -28,10 +28,14 @@ runs:
         # contents AND paths — a rename or move counts as a content change.
         # Include the rendering inputs (layout page, build scripts, config) so a
         # template/script/config edit busts the cache, not just content changes.
+        # bundle-test.html is excluded from the presentations PDF (it's a build
+        # test artifact, not a deck), so it must not feed the hash either —
+        # otherwise editing it would bust the cache without changing any output.
         files=$(find src/content/blog public/presentations \
           src/pages/archive-book.astro \
           scripts/build-archive-pdf.mjs scripts/build-presentations-pdf.mjs \
-          src/config -type f | LC_ALL=C sort)
+          src/config -type f \
+          ! -name bundle-test.html | LC_ALL=C sort)
         if [ -z "$files" ]; then
           echo "::error::No archive content inputs found (src/content/blog, public/presentations)." >&2
           exit 1

--- a/.github/actions/ensure-archive-pdfs/action.yml
+++ b/.github/actions/ensure-archive-pdfs/action.yml
@@ -84,8 +84,10 @@ runs:
 
         if [ "$regen" = "1" ]; then
           npx playwright install --with-deps chromium
-          # Render from the already-built dist/ (preview serves it). --skip-build
-          # avoids a second astro build; both PDFs are written straight into dist/.
+          # Blog archive: rendered from the already-built dist/ via astro preview
+          # (--skip-build avoids a second astro build). Presentations: rendered from
+          # public/presentations by the script's own static server (it never reads
+          # dist/). Both write their output straight into dist/.
           npm run archive:pdf -- --skip-build --output dist/blog-archive.pdf
           npm run archive:presentations -- --output dist/presentations-archive.pdf
           gh release upload "$TAG" \

--- a/.github/actions/ensure-archive-pdfs/action.yml
+++ b/.github/actions/ensure-archive-pdfs/action.yml
@@ -33,6 +33,7 @@ runs:
         # otherwise editing it would bust the cache without changing any output.
         files=$(find src/content/blog public/presentations \
           src/pages/archive-book.astro \
+          src/utils/getBlogPosts.ts src/utils/postFilter.ts src/content.config.ts \
           scripts/build-archive-pdf.mjs scripts/build-presentations-pdf.mjs \
           src/config -type f \
           ! -name bundle-test.html | LC_ALL=C sort)

--- a/.github/actions/ensure-archive-pdfs/action.yml
+++ b/.github/actions/ensure-archive-pdfs/action.yml
@@ -1,0 +1,98 @@
+name: Ensure archive PDFs
+description: >-
+  Make the archive PDFs (blog-archive.pdf, presentations-archive.pdf) present in
+  dist/ AFTER the site build, using a GitHub Release as an untracked backing
+  store. Regenerates the PDFs only when the rendering inputs have changed
+  (detected by hashing them); otherwise downloads the existing assets. Requires a
+  prior `npm run build` step — the regen path renders from the built dist/.
+
+inputs:
+  tag:
+    description: Release tag used as the backing store for the archive PDFs.
+    required: false
+    default: archive-pdfs
+  token:
+    description: GitHub token with contents:write to read/write the release.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Compute content hash
+      id: hash
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Deterministic file list (sorted) over the content inputs that affect the
+        # PDFs. sha256sum prints "<hash>  <path>", so the digest captures both file
+        # contents AND paths — a rename or move counts as a content change.
+        # Include the rendering inputs (layout page, build scripts, config) so a
+        # template/script/config edit busts the cache, not just content changes.
+        files=$(find src/content/blog public/presentations \
+          src/pages/archive-book.astro \
+          scripts/build-archive-pdf.mjs scripts/build-presentations-pdf.mjs \
+          src/config -type f | LC_ALL=C sort)
+        if [ -z "$files" ]; then
+          echo "::error::No archive content inputs found (src/content/blog, public/presentations)." >&2
+          exit 1
+        fi
+        hash=$(printf '%s\n' "$files" \
+          | while IFS= read -r f; do sha256sum "$f"; done \
+          | sha256sum | cut -d' ' -f1)
+        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+        echo "Content hash: $hash"
+
+    - name: Resolve archive PDFs (regenerate on change, else download)
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        TAG: ${{ inputs.tag }}
+        HASH: ${{ steps.hash.outputs.hash }}
+      run: |
+        set -euo pipefail
+        mkdir -p dist
+
+        # Read the hash stored alongside the release (its body holds the last
+        # generated content hash). Bootstrap the release if it does not exist yet.
+        stored=""
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          stored=$(gh release view "$TAG" --json body --jq '.body' | tr -d '[:space:]')
+        else
+          echo "Release '$TAG' missing — bootstrapping (non-latest/prerelease)."
+          gh release create "$TAG" \
+            --title "Archive PDFs (automation backing store)" \
+            --notes "$HASH" \
+            --latest=false \
+            --prerelease
+        fi
+
+        regen=0
+        if [ "$stored" != "$HASH" ]; then
+          echo "Content hash changed (stored='$stored' current='$HASH') — regenerating."
+          regen=1
+        elif ! gh release download "$TAG" --pattern blog-archive.pdf --dir dist --clobber 2>/dev/null \
+          || ! gh release download "$TAG" --pattern presentations-archive.pdf --dir dist --clobber 2>/dev/null; then
+          echo "Hash matched but a PDF asset is missing — regenerating."
+          regen=1
+        else
+          echo "Content unchanged — downloaded existing PDFs from release '$TAG'."
+        fi
+
+        if [ "$regen" = "1" ]; then
+          npx playwright install --with-deps chromium
+          # Render from the already-built dist/ (preview serves it). --skip-build
+          # avoids a second astro build; both PDFs are written straight into dist/.
+          npm run archive:pdf -- --skip-build --output dist/blog-archive.pdf
+          npm run archive:presentations -- --output dist/presentations-archive.pdf
+          gh release upload "$TAG" \
+            dist/blog-archive.pdf \
+            dist/presentations-archive.pdf \
+            --clobber
+          # Persist the new content hash so the next deploy can compare against it.
+          gh release edit "$TAG" --notes "$HASH"
+        fi
+
+        # Fail loudly if, after all paths, the PDFs are not present in the deployable.
+        test -f dist/blog-archive.pdf || { echo "::error::blog-archive.pdf missing after ensure step." >&2; exit 1; }
+        test -f dist/presentations-archive.pdf || { echo "::error::presentations-archive.pdf missing after ensure step." >&2; exit 1; }
+        echo "Archive PDFs ready in dist/."

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       name: production
       url: https://kyle.skrinak.com
     permissions:
-      contents: read
+      contents: write  # ensure-archive-pdfs reads/writes the release backing store
       id-token: write  # needed for OIDC -> AWS
     steps:
       - name: Checkout
@@ -54,6 +54,14 @@ jobs:
           PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN_PROD }}
           PUBLIC_GOOGLE_SITE_VERIFICATION: ${{ secrets.GOOGLE_SITE_VERIFICATION_PROD }}
           PUBLIC_GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+
+      # Runs AFTER the build: renders the PDFs from the built dist/ and writes
+      # them into dist/ so the S3 sync picks them up. Production uses the default
+      # release tag (archive-pdfs) as its backing store.
+      - name: Ensure archive PDFs
+        uses: ./.github/actions/ensure-archive-pdfs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # ensure-archive-pdfs reads/writes the release backing store
     steps:
       - name: Checkout code
         # Pinned to SHA (v4) — consistent supply-chain posture across all workflows.
@@ -51,6 +53,15 @@ jobs:
           PUBLIC_DEPLOY_ENV: staging
           SITE_URL: https://kyleskrinak.github.io/
           PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN_STAGING }}
+
+      # Runs AFTER the build (renders from the built dist/) but BEFORE the artifact
+      # upload so the PDFs ship in the deployed artifact. Staging uses its own
+      # release tag so it never shares prod's backing store (no cross-env race).
+      - name: Ensure archive PDFs
+        uses: ./.github/actions/ensure-archive-pdfs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: archive-pdfs-staging
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ tmp/
 
 # Claude Code runtime state (transient lock/scheduler files, not project content)
 .claude/scheduled_tasks.lock
+
+# Generated archive PDFs — untracked; built in CI and stored on a GitHub Release
+# asset, fetched into public/ at deploy time. See .github/actions/ensure-archive-pdfs.
+public/blog-archive.pdf
+public/presentations-archive.pdf

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -14,3 +14,9 @@ IgnoreURLs:
   - "claude.ai"  # Connection reset in htmltest, works in browser
   - "drupal.org/u/grasmash"  # Intermittent timeouts, works in real browsers
   - "linkedin.com"  # Bot detection (999/404 to crawlers), works in real browsers
+IgnoreInternalURLs:
+  # Archive PDFs are .gitignored and absent from a plain `npm run build`; the
+  # deploy pipeline guarantees them via the ensure-archive-pdfs action's `test -f`
+  # guards, so ignoring them here cannot mask a real production regression.
+  - "/blog-archive.pdf"
+  - "/presentations-archive.pdf"

--- a/config/validate.mjs
+++ b/config/validate.mjs
@@ -327,6 +327,7 @@ const testEnvVars = new Set([
   'CI',                             // CI detection (scripts/lib/browser-mode.js)
   'DISPLAY',                        // X11 display (scripts/lib/browser-mode.js)
   'WAYLAND_DISPLAY',                // Wayland display (scripts/lib/browser-mode.js)
+  'ARCHIVE_PREVIEW_PORT',           // scripts/build-archive-pdf.mjs (preview port override)
 ]);
 
 // Scan all TypeScript/JavaScript files in src/ and scripts/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "build:presentations": "node scripts/build-presentations.js",
     "check:images": "node scripts/check-image-conventions.mjs --all",
     "new-post": "node scripts/new-post.mjs",
+    "archive:pdf": "node scripts/build-archive-pdf.mjs",
+    "archive:presentations": "node scripts/build-presentations-pdf.mjs",
     "preview": "astro preview",
     "sync": "astro sync",
     "astro": "astro",

--- a/scripts/build-archive-pdf.mjs
+++ b/scripts/build-archive-pdf.mjs
@@ -79,8 +79,9 @@ async function main() {
     baseUrl = `http://localhost:${PORT}`;
     console.log(`→ Starting astro preview on :${PORT}…`);
     preview = spawn("npx", ["astro", "preview", "--port", String(PORT)], {
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "inherit"], // surface astro errors (e.g. port in use)
       cwd: ROOT,
+      detached: true, // own process group so we can kill the whole tree
     });
     await waitForServer(baseUrl + "/");
   }
@@ -171,7 +172,13 @@ async function main() {
     console.log(`✅ Wrote ${args.output} (${(size / 1024 / 1024).toFixed(2)} MB)`);
   } finally {
     if (browser) await browser.close();
-    if (preview) preview.kill("SIGTERM");
+    if (preview && preview.pid) {
+      try {
+        process.kill(-preview.pid, "SIGTERM"); // kill the group, not just npx
+      } catch {
+        /* already exited */
+      }
+    }
   }
 }
 

--- a/scripts/build-archive-pdf.mjs
+++ b/scripts/build-archive-pdf.mjs
@@ -121,6 +121,22 @@ async function main() {
     });
     if (rewritten > 0) console.log(`  · replaced ${rewritten} embed(s) with printed URLs`);
 
+    // 4a-bis. Tag external links whose visible text already IS their href, so the
+    // print CSS (.chapter a[href^="http"]::after { content: " (" attr(href) ")" })
+    // does not print the URL twice (e.g. `[https://x](https://x)` or `<https://x>`).
+    const tagged = await page.evaluate(() => {
+      const links = Array.from(document.querySelectorAll('.chapter a[href^="http"]'));
+      let n = 0;
+      for (const a of links) {
+        if (a.textContent.trim() === a.getAttribute("href")) {
+          a.classList.add("url-in-text");
+          n++;
+        }
+      }
+      return n;
+    });
+    if (tagged > 0) console.log(`  · tagged ${tagged} self-URL link(s) to avoid duplicate printing`);
+
     // 4b. Force lazy images to load: this is one tall page, so off-screen images
     // with loading="lazy" never enter the viewport in headless. Mark them eager
     // and scroll the full height to trigger their fetch.
@@ -174,6 +190,9 @@ async function main() {
     if (browser) await browser.close();
     if (preview && preview.pid) {
       try {
+        // POSIX-only: negative PID signals the whole process group (macOS/ubuntu
+        // CI runners). Windows has no process groups; this path would need a
+        // different teardown there, but the build pipeline never runs on Windows.
         process.kill(-preview.pid, "SIGTERM"); // kill the group, not just npx
       } catch {
         /* already exited */

--- a/scripts/build-archive-pdf.mjs
+++ b/scripts/build-archive-pdf.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Generate the complete-archive PDF book from the `/archive-book/` print page.
+ *
+ *   node scripts/build-archive-pdf.mjs [--output <path>] [--skip-build] [--base-url <url>]
+ *   npm run archive:pdf
+ *
+ * Pipeline: `astro build` -> `astro preview` -> Chromium renders /archive-book/
+ * to a 6x9in PDF. Uses the Chromium already installed with @playwright/test, so
+ * it needs no extra dependency and renders MDX, components, and WebP at full
+ * fidelity (Astro has already resolved those into plain HTML + optimized images).
+ *
+ * Privacy safeguards baked in (see the archive discussion):
+ *   - Post selection is delegated entirely to the page, which reuses the site's
+ *     own publish filter — the book can never include drafts or future-dated posts.
+ *   - Inline images are the Astro-optimized variants, which are re-encoded by
+ *     sharp with metadata (EXIF/GPS) stripped — no photo geolocation leaks.
+ *   - The emitted PDF metadata comes from Chromium (Title from <title>, generic
+ *     Creator/Producer) and embeds no local username or file paths.
+ *   - Non-printable <iframe> embeds are replaced with a visible caption + the URL,
+ *     so references survive without pulling third-party frames into the file.
+ */
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { chromium } from "@playwright/test";
+
+const ROOT = process.cwd();
+
+function parseArgs(argv) {
+  const args = { output: "public/blog-archive.pdf", skipBuild: false, baseUrl: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--output") args.output = argv[++i];
+    else if (a === "--skip-build") args.skipBuild = true;
+    else if (a === "--base-url") args.baseUrl = argv[++i];
+    else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+const PORT = Number(process.env.ARCHIVE_PREVIEW_PORT || 4321);
+
+async function waitForServer(url, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { method: "GET" });
+      if (res.ok || res.status === 404) return; // server is up and answering
+    } catch {
+      // not ready yet
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error(`Preview server did not become ready at ${url} within ${timeoutMs}ms`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outputPath = resolve(ROOT, args.output);
+
+  // 1. Build (unless reusing an existing dist or an external server).
+  if (!args.baseUrl && !args.skipBuild) {
+    console.log("→ Building site (astro build)…");
+    const build = spawnSync("npx", ["astro", "build"], { stdio: "inherit", cwd: ROOT });
+    if (build.status !== 0) {
+      console.error("✘ astro build failed.");
+      process.exit(build.status ?? 1);
+    }
+  }
+
+  // 2. Start a preview server unless one was supplied.
+  let preview = null;
+  let baseUrl = args.baseUrl;
+  if (!baseUrl) {
+    baseUrl = `http://localhost:${PORT}`;
+    console.log(`→ Starting astro preview on :${PORT}…`);
+    preview = spawn("npx", ["astro", "preview", "--port", String(PORT)], {
+      stdio: "ignore",
+      cwd: ROOT,
+    });
+    await waitForServer(baseUrl + "/");
+  }
+
+  const pageUrl = `${baseUrl.replace(/\/$/, "")}/archive-book/`;
+  let browser = null;
+  try {
+    // 3. Render to PDF.
+    console.log(`→ Rendering ${pageUrl} → ${args.output}`);
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+    // Use "load", not "networkidle": video-embed iframes keep connections alive,
+    // so the network never goes idle on this page.
+    const resp = await page.goto(pageUrl, { waitUntil: "load", timeout: 120000 });
+    if (!resp || !resp.ok()) {
+      throw new Error(`Failed to load ${pageUrl} (status ${resp ? resp.status() : "none"})`);
+    }
+
+    // 4a. Replace non-printable iframe embeds FIRST — before any waiting — so the
+    // embedded players stop holding network connections open.
+    const rewritten = await page.evaluate(() => {
+      const frames = Array.from(document.querySelectorAll("iframe"));
+      for (const frame of frames) {
+        const src = frame.getAttribute("src") || "";
+        const fallback = document.createElement("div");
+        fallback.className = "print-embed-fallback";
+        const label = document.createElement("div");
+        label.textContent = "Embedded media (view online):";
+        const link = document.createElement("div");
+        link.className = "url";
+        link.textContent = src;
+        fallback.appendChild(label);
+        fallback.appendChild(link);
+        frame.replaceWith(fallback);
+      }
+      return frames.length;
+    });
+    if (rewritten > 0) console.log(`  · replaced ${rewritten} embed(s) with printed URLs`);
+
+    // 4b. Force lazy images to load: this is one tall page, so off-screen images
+    // with loading="lazy" never enter the viewport in headless. Mark them eager
+    // and scroll the full height to trigger their fetch.
+    await page.evaluate(async () => {
+      for (const img of document.images) img.loading = "eager";
+      const step = window.innerHeight || 800;
+      for (let y = 0; y < document.body.scrollHeight; y += step) {
+        window.scrollTo(0, y);
+        await new Promise(r => setTimeout(r, 40));
+      }
+      window.scrollTo(0, 0);
+    });
+
+    // 4c. Wait for fonts + images to settle, but CAP the wait so a single image
+    // that never fires load/error can never hang the whole run.
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+      const imgs = Array.from(document.images);
+      await Promise.race([
+        Promise.all(
+          imgs.map(img =>
+            img.complete
+              ? Promise.resolve()
+              : new Promise(res => {
+                  img.addEventListener("load", res, { once: true });
+                  img.addEventListener("error", res, { once: true });
+                })
+          )
+        ),
+        new Promise(r => setTimeout(r, 15000)),
+      ]);
+    });
+
+    // 5. Emit the PDF. preferCSSPageSize honours the page's @page 6x9in rule.
+    await mkdir(dirname(outputPath), { recursive: true });
+    await page.pdf({
+      path: outputPath,
+      printBackground: true,
+      preferCSSPageSize: true,
+      displayHeaderFooter: true,
+      headerTemplate: "<span></span>",
+      footerTemplate:
+        '<div style="width:100%;text-align:center;font-size:8pt;color:#666;">' +
+        'Page <span class="pageNumber"></span> of <span class="totalPages"></span>' +
+        "</div>",
+    });
+
+    const { size } = await stat(outputPath);
+    console.log(`✅ Wrote ${args.output} (${(size / 1024 / 1024).toFixed(2)} MB)`);
+  } finally {
+    if (browser) await browser.close();
+    if (preview) preview.kill("SIGTERM");
+  }
+}
+
+main().catch(err => {
+  console.error(`✘ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/build-archive-pdf.mjs
+++ b/scripts/build-archive-pdf.mjs
@@ -29,11 +29,20 @@ const ROOT = process.cwd();
 
 function parseArgs(argv) {
   const args = { output: "public/blog-archive.pdf", skipBuild: false, baseUrl: null };
+  // Guard flags that take a value: a missing value (end of argv) or another flag
+  // in its place is a usage error, not a silent `undefined` that fails later.
+  const needValue = (flag, value) => {
+    if (value === undefined || value.startsWith("--")) {
+      console.error(`Missing value for ${flag}`);
+      process.exit(2);
+    }
+    return value;
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--output") args.output = argv[++i];
+    if (a === "--output") args.output = needValue("--output", argv[++i]);
     else if (a === "--skip-build") args.skipBuild = true;
-    else if (a === "--base-url") args.baseUrl = argv[++i];
+    else if (a === "--base-url") args.baseUrl = needValue("--base-url", argv[++i]);
     else {
       console.error(`Unknown argument: ${a}`);
       process.exit(2);

--- a/scripts/build-presentations-pdf.mjs
+++ b/scripts/build-presentations-pdf.mjs
@@ -49,8 +49,17 @@ const MIME = {
 
 function parseArgs(argv) {
   const args = { output: "public/presentations-archive.pdf" };
+  // Guard flags that take a value: a missing value (end of argv) or another flag
+  // in its place is a usage error, not a silent `undefined` that fails later.
+  const needValue = (flag, value) => {
+    if (value === undefined || value.startsWith("--")) {
+      console.error(`Missing value for ${flag}`);
+      process.exit(2);
+    }
+    return value;
+  };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--output") args.output = argv[++i];
+    if (argv[i] === "--output") args.output = needValue("--output", argv[++i]);
     else {
       console.error(`Unknown argument: ${argv[i]}`);
       process.exit(2);

--- a/scripts/build-presentations-pdf.mjs
+++ b/scripts/build-presentations-pdf.mjs
@@ -23,7 +23,7 @@
  */
 import { createServer } from "node:http";
 import { readFile, readdir, mkdir, stat } from "node:fs/promises";
-import { dirname, resolve, join, extname, basename } from "node:path";
+import { dirname, resolve, join, extname, basename, sep } from "node:path";
 import { chromium } from "@playwright/test";
 
 const ROOT = process.cwd();
@@ -69,9 +69,10 @@ function startStaticServer() {
     const server = createServer(async (req, res) => {
       try {
         const urlPath = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
-        const filePath = join(PUBLIC_DIR, urlPath);
-        // Contain within public/ (defense against traversal).
-        if (!filePath.startsWith(PUBLIC_DIR)) {
+        const filePath = resolve(PUBLIC_DIR, "." + urlPath);
+        // Contain within public/ (defense against traversal). Compare against
+        // PUBLIC_DIR + separator so a sibling dir (e.g. "public-x") can't escape.
+        if (filePath !== PUBLIC_DIR && !filePath.startsWith(PUBLIC_DIR + sep)) {
           res.statusCode = 403;
           return res.end("Forbidden");
         }
@@ -192,6 +193,9 @@ async function main() {
         continue;
       }
       if (!sharedStyle) sharedStyle = extracted.style;
+      else if (extracted.style.trim() !== sharedStyle.trim()) {
+        console.warn(`  · ${file} has a different stylesheet; combined PDF assumes uniform decks`);
+      }
       decks.push({ file, title: extracted.title || basename(file, ".html"), html: extracted.container });
       console.log(`  · ${file}`);
     }

--- a/scripts/build-presentations-pdf.mjs
+++ b/scripts/build-presentations-pdf.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Generate a single landscape PDF of all standalone presentation decks.
+ *
+ *   node scripts/build-presentations-pdf.mjs [--output <path>]
+ *   npm run archive:presentations
+ *
+ * The decks in public/presentations/*.html are navigated single-slide views
+ * (each `.slide` is position:absolute / display:none, shown one at a time by
+ * JavaScript). They are all produced by the same generateHtml() template, so
+ * they share an identical stylesheet. This script:
+ *   1. serves public/ over HTTP so decks' root-relative assets (/presentations/
+ *      assets/...) resolve,
+ *   2. loads each deck and extracts its `.presentation-container` markup + title,
+ *   3. concatenates every deck into one document with a single copy of the
+ *      shared stylesheet plus a print override that reveals every slide and
+ *      lays each out as one 16:9 landscape page,
+ *   4. prepends a linked table of contents, puts a blank page between decks,
+ *      and prints the combined document to one PDF via Chromium.
+ *
+ * No PDF-merge dependency: it relies on the decks being uniform. Navigation
+ * <script>s are intentionally dropped (markup only is extracted).
+ */
+import { createServer } from "node:http";
+import { readFile, readdir, mkdir, stat } from "node:fs/promises";
+import { dirname, resolve, join, extname, basename } from "node:path";
+import { chromium } from "@playwright/test";
+
+const ROOT = process.cwd();
+const PUBLIC_DIR = join(ROOT, "public");
+const DECKS_DIR = join(PUBLIC_DIR, "presentations");
+// Page geometry: 1280x720 CSS px at 96dpi = 13.333in x 7.5in (16:9).
+const PAGE_W = "13.333in";
+const PAGE_H = "7.5in";
+
+const MIME = {
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "text/javascript",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".avif": "image/avif",
+  ".ico": "image/x-icon",
+};
+
+function parseArgs(argv) {
+  const args = { output: "public/presentations-archive.pdf" };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--output") args.output = argv[++i];
+    else {
+      console.error(`Unknown argument: ${argv[i]}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function escapeHtml(s) {
+  return s.replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]);
+}
+
+// Minimal static file server rooted at public/, so /presentations/assets/* resolve.
+function startStaticServer() {
+  return new Promise((resolveServer, rejectServer) => {
+    const server = createServer(async (req, res) => {
+      try {
+        const urlPath = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+        const filePath = join(PUBLIC_DIR, urlPath);
+        // Contain within public/ (defense against traversal).
+        if (!filePath.startsWith(PUBLIC_DIR)) {
+          res.statusCode = 403;
+          return res.end("Forbidden");
+        }
+        const data = await readFile(filePath);
+        res.setHeader("Content-Type", MIME[extname(filePath).toLowerCase()] || "application/octet-stream");
+        res.end(data);
+      } catch {
+        res.statusCode = 404;
+        res.end("Not found");
+      }
+    });
+    server.on("error", rejectServer);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolveServer({ server, port });
+    });
+  });
+}
+
+const PRINT_OVERRIDES = `
+  @page { size: ${PAGE_W} ${PAGE_H}; margin: 0; }
+  html, body {
+    overflow: visible !important;
+    width: 100% !important;
+    height: auto !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: #fff !important;
+  }
+  .controls, .presenter-window, .slide-nav, .progress-bar, #progressBar { display: none !important; }
+  /* Neutralise the deck's viewport-centring layout so slides stack and each
+     slide fills exactly one printed page (vw/vh map to the @page box). */
+  .presentation-container, .slides-wrapper {
+    position: static !important;
+    width: 100% !important;
+    height: auto !important;
+    display: block !important;
+    transform: none !important;
+    align-items: initial !important;
+    justify-content: initial !important;
+  }
+  .slide {
+    position: relative !important;
+    display: flex !important;
+    width: 100vw !important;
+    height: 100vh !important;
+    margin: 0 !important;
+    top: 0 !important;
+    left: 0 !important;
+    overflow: hidden !important;
+    animation: none !important;
+    break-after: page;
+    page-break-after: always;
+  }
+  /* Keep oversized media inside the page. */
+  .slide img, .slide svg, .slide video, .slide table {
+    max-width: 100% !important;
+    max-height: 78vh !important;
+    height: auto !important;
+    object-fit: contain;
+  }
+  .blank-page { height: ${PAGE_H}; break-after: page; page-break-after: always; }
+  .toc-page {
+    height: ${PAGE_H};
+    box-sizing: border-box;
+    padding: 0.7in 0.9in;
+    color: #111;
+    background: #fff;
+    break-after: page;
+    page-break-after: always;
+    font-family: Georgia, "Times New Roman", serif;
+  }
+  .toc-page h1 { font-size: 26pt; margin: 0 0 0.35in; }
+  .toc-page ol { font-size: 15pt; line-height: 2; padding-left: 0.4in; }
+  .toc-page a { color: #1a4d8f; text-decoration: none; }
+`;
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outputPath = resolve(ROOT, args.output);
+
+  // Exclude bundle-test.html — a build test artifact, not a real deck.
+  const EXCLUDE = new Set(["bundle-test.html"]);
+  const files = (await readdir(DECKS_DIR))
+    .filter(f => f.endsWith(".html") && !EXCLUDE.has(f))
+    .sort();
+  if (files.length === 0) {
+    console.error(`✘ No decks found in ${DECKS_DIR}`);
+    process.exit(1);
+  }
+
+  const { server, port } = await startStaticServer();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+
+    // 1. Extract markup, shared stylesheet (once), and title from each deck.
+    let sharedStyle = "";
+    const decks = [];
+    for (const file of files) {
+      const resp = await page.goto(`${baseUrl}/presentations/${file}`, {
+        waitUntil: "load",
+        timeout: 60000,
+      });
+      if (!resp || !resp.ok()) {
+        throw new Error(`Failed to load ${file} (status ${resp ? resp.status() : "none"})`);
+      }
+      const extracted = await page.evaluate(() => {
+        const style = Array.from(document.querySelectorAll("style"))
+          .map(s => s.textContent)
+          .join("\n");
+        const container = document.querySelector(".presentation-container");
+        return { style, title: document.title || "", container: container ? container.outerHTML : null };
+      });
+      if (!extracted.container) {
+        console.warn(`  · skipping ${file} (no .presentation-container)`);
+        continue;
+      }
+      if (!sharedStyle) sharedStyle = extracted.style;
+      decks.push({ file, title: extracted.title || basename(file, ".html"), html: extracted.container });
+      console.log(`  · ${file}`);
+    }
+    if (decks.length === 0) throw new Error("No printable decks extracted.");
+
+    // 2. Build the combined document: TOC, then decks with blank-page separators.
+    const toc = `<section class="toc-page">
+      <h1>Presentations — Contents</h1>
+      <ol>${decks
+        .map((d, i) => `<li><a href="#deck-${i}">${escapeHtml(d.title)}</a></li>`)
+        .join("")}</ol>
+    </section>`;
+
+    const deckBlocks = decks
+      .map(
+        (d, i) =>
+          `<div class="deck" id="deck-${i}" data-deck="${escapeHtml(basename(d.file))}">${d.html}</div>` +
+          (i < decks.length - 1 ? `<div class="blank-page"></div>` : "")
+      )
+      .join("\n");
+
+    const combined = `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<base href="${baseUrl}/">
+<style>${sharedStyle}</style>
+<style>${PRINT_OVERRIDES}</style>
+</head><body>${toc}${deckBlocks}</body></html>`;
+
+    await page.setContent(combined, { waitUntil: "load" });
+
+    // Force lazy images and wait, capped so a stuck asset cannot hang the run.
+    await page.evaluate(async () => {
+      for (const img of document.images) img.loading = "eager";
+      await document.fonts.ready;
+      const imgs = Array.from(document.images);
+      await Promise.race([
+        Promise.all(
+          imgs.map(img =>
+            img.complete
+              ? Promise.resolve()
+              : new Promise(res => {
+                  img.addEventListener("load", res, { once: true });
+                  img.addEventListener("error", res, { once: true });
+                })
+          )
+        ),
+        new Promise(r => setTimeout(r, 15000)),
+      ]);
+    });
+
+    // 3. Print.
+    await mkdir(dirname(outputPath), { recursive: true });
+    await page.pdf({
+      path: outputPath,
+      width: PAGE_W,
+      height: PAGE_H,
+      printBackground: true,
+      preferCSSPageSize: true,
+    });
+
+    const { size } = await stat(outputPath);
+    console.log(
+      `✅ Wrote ${args.output} — ${decks.length} deck(s), ${(size / 1024 / 1024).toFixed(2)} MB`
+    );
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+main().catch(err => {
+  console.error(`✘ ${err.message}`);
+  process.exit(1);
+});

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -61,6 +61,15 @@ import { SITE } from "@/config";
 				Since June 2017, I've followed a low-carb diet under the guidance of Dr. Eric Westman at Duke University. It's transformed my health and helped me maintain sustainable weight loss. I write about this journey regularly on the blog. For my full story, resources, and recommendations, read <a href={linkWithBase("/lchf/")}>my low-carb living page</a>.
 			</p>
 
+			<h2>Archive</h2>
+			<p>
+				The complete contents of this blog are also available as self-contained PDF files, so the writing stays readable on its own even if this site someday goes away. Each is a single document with everything included — no website or special software required.
+			</p>
+			<ul>
+				<li><a href={linkWithBase("/blog-archive.pdf")}>Collected writing (PDF)</a> — every post, in chronological order.</li>
+				<li><a href={linkWithBase("/presentations-archive.pdf")}>Presentations (PDF)</a> — the full slide decks.</li>
+			</ul>
+
 			<h2>Get in Touch</h2>
 			<p>
 				You can find me on <a href="https://github.com/kyleskrinak">GitHub</a>, <a href="https://www.linkedin.com/in/kyleskrinak/">LinkedIn</a>, or <a href="https://x.com/screenack">X</a>.

--- a/src/pages/archive-book.astro
+++ b/src/pages/archive-book.astro
@@ -48,8 +48,10 @@ const lastYear = posts.length
 // stable across re-exports, so the visible colophon only changes on real content
 // updates. NOTE: this does NOT make the PDF byte-identical — Chromium stamps a
 // wall-clock /CreationDate + /ModDate into every render, so re-runs always differ
-// at the byte level. Regenerate + commit the binary only when post content
-// actually changes (manual discipline; see archive-pdf-regeneration-policy).
+// at the byte level. That byte-instability is why the deploy pipeline keys
+// regeneration on a content hash, not the PDF bytes: CI regenerates and re-uploads
+// the PDF to its release-backed store only when post content changes. The PDF is
+// untracked — never commit the binary (see .github/actions/ensure-archive-pdfs).
 const latestContent = posts.reduce((max, p) => {
   const t = new Date(p.data.updatedDate || p.data.pubDate).getTime();
   return t > max ? t : max;

--- a/src/pages/archive-book.astro
+++ b/src/pages/archive-book.astro
@@ -44,8 +44,12 @@ const lastYear = posts.length
   ? new Date(posts[posts.length - 1].data.pubDate).getFullYear()
   : firstYear;
 // Date the content was last updated (latest post's updatedDate or pubDate). Using
-// the content date — not today's clock — keeps a re-export byte-identical when no
-// posts have changed, so the committed PDF only churns on real content updates.
+// the content date — not today's clock — keeps the printed "current as of" date
+// stable across re-exports, so the visible colophon only changes on real content
+// updates. NOTE: this does NOT make the PDF byte-identical — Chromium stamps a
+// wall-clock /CreationDate + /ModDate into every render, so re-runs always differ
+// at the byte level. Regenerate + commit the binary only when post content
+// actually changes (manual discipline; see archive-pdf-regeneration-policy).
 const latestContent = posts.reduce((max, p) => {
   const t = new Date(p.data.updatedDate || p.data.pubDate).getTime();
   return t > max ? t : max;
@@ -208,6 +212,14 @@ const title = `${SITE.author} — Collected Writing`;
         color: inherit;
         text-decoration: none;
       }
+      /* Preserve external link destinations in print (the live site may be gone).
+         Scoped to post bodies so cover/colophon/TOC links stay clean. */
+      .chapter a[href^="http"]::after {
+        content: " (" attr(href) ")";
+        font-size: 9pt;
+        color: #1a4d8f;
+        word-break: break-all;
+      }
       /* Fallback rendered in place of non-printable embeds by the build script */
       .print-embed-fallback {
         border: 1px solid #999;
@@ -259,9 +271,9 @@ const title = `${SITE.author} — Collected Writing`;
         {
           chapters.map(({ post }, i) => (
             <li>
-              <span class="toc-title">
+              <a class="toc-title" href={`#chapter-${i}`}>
                 {i + 1}. {post.data.title}
-              </span>
+              </a>
               <span class="toc-date">{fmtDate(post.data.pubDate)}</span>
             </li>
           ))
@@ -270,8 +282,8 @@ const title = `${SITE.author} — Collected Writing`;
     </nav>
 
     {
-      chapters.map(({ post, Content }) => (
-        <article class="chapter">
+      chapters.map(({ post, Content }, i) => (
+        <article class="chapter" id={`chapter-${i}`}>
           <header>
             <h2>{post.data.title}</h2>
             <div class="chapter-date">{fmtDate(post.data.pubDate)}</div>

--- a/src/pages/archive-book.astro
+++ b/src/pages/archive-book.astro
@@ -5,7 +5,8 @@
  * This page assembles every genuinely-live post into a single, self-describing
  * document sized for a 6x9in trade book. It is NOT meant to be browsed: it is
  * `noindex`, excluded from the sitemap, and carries no Pagefind body marker.
- * `scripts/build-archive-pdf.mjs` renders it to `public/blog-archive.pdf`.
+ * `scripts/build-archive-pdf.mjs` renders it to a PDF (default
+ * public/blog-archive.pdf; the CI deploy writes it into dist/ via --output).
  *
  * Post selection mirrors the live site exactly:
  *   - getBlogPosts() drops drafts (`published: false`) in production builds.

--- a/src/pages/archive-book.astro
+++ b/src/pages/archive-book.astro
@@ -213,8 +213,10 @@ const title = `${SITE.author} — Collected Writing`;
         text-decoration: none;
       }
       /* Preserve external link destinations in print (the live site may be gone).
-         Scoped to post bodies so cover/colophon/TOC links stay clean. */
-      .chapter a[href^="http"]::after {
+         Scoped to post bodies so cover/colophon/TOC links stay clean.
+         :not(.url-in-text) skips links whose visible text already IS the URL —
+         the build script tags those so the destination isn't printed twice. */
+      .chapter a[href^="http"]:not(.url-in-text)::after {
         content: " (" attr(href) ")";
         font-size: 9pt;
         color: #1a4d8f;

--- a/src/pages/archive-book.astro
+++ b/src/pages/archive-book.astro
@@ -1,0 +1,305 @@
+---
+/**
+ * Print source for the complete-archive PDF book.
+ *
+ * This page assembles every genuinely-live post into a single, self-describing
+ * document sized for a 6x9in trade book. It is NOT meant to be browsed: it is
+ * `noindex`, excluded from the sitemap, and carries no Pagefind body marker.
+ * `scripts/build-archive-pdf.mjs` renders it to `public/blog-archive.pdf`.
+ *
+ * Post selection mirrors the live site exactly:
+ *   - getBlogPosts() drops drafts (`published: false`) in production builds.
+ *   - postFilter drops not-yet-due scheduled posts (future pubDate) in prod.
+ * So the book can never contain anything the public site does not already show.
+ */
+import { Image } from "astro:assets";
+import { render } from "astro:content";
+import { getBlogPosts } from "@/utils/getBlogPosts";
+import postFilter from "@/utils/postFilter";
+import { SITE } from "@/config";
+
+const posts = (await getBlogPosts())
+  .filter(postFilter)
+  .sort(
+    (a, b) =>
+      new Date(a.data.pubDate).getTime() - new Date(b.data.pubDate).getTime()
+  );
+
+const chapters = await Promise.all(
+  posts.map(async post => ({ post, Content: (await render(post)).Content }))
+);
+
+const fmtDate = (d: Date | string) =>
+  new Date(d).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: SITE.timezone,
+  });
+
+const firstYear = posts.length
+  ? new Date(posts[0].data.pubDate).getFullYear()
+  : new Date().getFullYear();
+const lastYear = posts.length
+  ? new Date(posts[posts.length - 1].data.pubDate).getFullYear()
+  : firstYear;
+// Date the content was last updated (latest post's updatedDate or pubDate). Using
+// the content date — not today's clock — keeps a re-export byte-identical when no
+// posts have changed, so the committed PDF only churns on real content updates.
+const latestContent = posts.reduce((max, p) => {
+  const t = new Date(p.data.updatedDate || p.data.pubDate).getTime();
+  return t > max ? t : max;
+}, 0);
+const currentAsOf = posts.length ? fmtDate(new Date(latestContent)) : fmtDate(new Date());
+const title = `${SITE.author} — Collected Writing`;
+---
+
+<!doctype html>
+<html lang={SITE.lang || "en"}>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <title>{title}</title>
+    <style is:global>
+      @page {
+        size: 6in 9in;
+        margin: 0.75in 0.625in;
+      }
+
+      :root {
+        font-family: Georgia, "Times New Roman", serif;
+        color: #111;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 0;
+        font-size: 11pt;
+      }
+
+      /* Front matter — each on its own page */
+      .cover,
+      .colophon,
+      .toc {
+        break-after: page;
+      }
+
+      .cover {
+        height: 7.5in;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        text-align: center;
+      }
+      .cover h1 {
+        font-size: 30pt;
+        margin: 0 0 0.3in;
+        line-height: 1.15;
+      }
+      .cover .range {
+        font-size: 14pt;
+        color: #444;
+      }
+      .cover .site {
+        margin-top: 1in;
+        font-size: 11pt;
+        color: #555;
+      }
+
+      .colophon h2,
+      .toc h2 {
+        font-size: 16pt;
+        margin: 0 0 0.25in;
+      }
+      .colophon p {
+        margin: 0 0 0.16in;
+      }
+
+      .toc ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .toc li {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.25in;
+        padding: 0.04in 0;
+        border-bottom: 1px dotted #bbb;
+      }
+      .toc .toc-date {
+        color: #666;
+        white-space: nowrap;
+        font-size: 10pt;
+      }
+
+      /* One chapter per post */
+      .chapter {
+        break-before: page;
+      }
+      .chapter > header {
+        margin-bottom: 0.2in;
+        border-bottom: 2px solid #111;
+        padding-bottom: 0.08in;
+      }
+      .chapter h2 {
+        font-size: 19pt;
+        margin: 0 0 0.05in;
+        line-height: 1.15;
+      }
+      .chapter .chapter-date {
+        color: #555;
+        font-size: 10pt;
+      }
+
+      /* Post hero image */
+      .hero-image {
+        margin: 0.2in 0 0.25in;
+        text-align: center;
+        break-inside: avoid;
+      }
+      .hero-image img {
+        display: block;
+        margin: 0 auto;
+        width: auto;
+        height: auto;
+        /* Absolute caps: content width is 6in - 2x0.625in = 4.75in. Cap a touch
+           under that, and limit height so a hero never dominates a page. */
+        max-width: 4.6in;
+        max-height: 4in;
+        border-radius: 4px;
+      }
+      .hero-image figcaption {
+        margin-top: 0.06in;
+        font-size: 9.5pt;
+        font-style: italic;
+        color: #555;
+      }
+
+      /* Keep headings with following content; avoid orphaned media */
+      h1,
+      h2,
+      h3,
+      h4 {
+        break-after: avoid;
+      }
+      figure,
+      img,
+      pre,
+      table {
+        break-inside: avoid;
+      }
+      img {
+        max-width: 100%;
+        /* Cap height so tall portrait photos never bleed past the printable
+           area (6x9in page minus 0.75in top/bottom margins = ~7.5in). */
+        max-height: 7in;
+        height: auto;
+        object-fit: contain;
+      }
+      pre {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        font-size: 9pt;
+        background: #f4f4f4;
+        padding: 0.1in;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      /* Fallback rendered in place of non-printable embeds by the build script */
+      .print-embed-fallback {
+        border: 1px solid #999;
+        padding: 0.12in;
+        margin: 0.15in 0;
+        font-size: 10pt;
+        color: #333;
+      }
+      .print-embed-fallback .url {
+        word-break: break-all;
+        color: #1a4d8f;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="cover">
+      <h1>{SITE.author}<br />Collected Writing</h1>
+      <div class="range">{firstYear}–{lastYear}</div>
+      <div class="site">{SITE.website.replace(/^https?:\/\//, "").replace(/\/$/, "")}</div>
+    </section>
+
+    <section class="colophon">
+      <h2>About this book</h2>
+      <p>
+        This is a complete archive of the writing published at {SITE.website.replace(/^https?:\/\//, "").replace(/\/$/, "")},
+        current as of {currentAsOf}. It contains {posts.length} pieces written between
+        {firstYear} and {lastYear}, arranged in the order they were written, oldest first.
+      </p>
+      <p>
+        Nothing else is needed to read it. This single file is self-contained:
+        the words and images are all here. You do not need the website, any
+        account, or any special software beyond whatever you are already using to
+        view this page.
+      </p>
+      <p>
+        It was made so that the writing would remain readable on its own, apart
+        from any website that may or may not still exist when you find this.
+      </p>
+      <p>
+        Written by {SITE.author}. Where a piece links to a video or other online
+        material that cannot be printed, the web address is shown in its place so
+        the reference is preserved.
+      </p>
+    </section>
+
+    <nav class="toc">
+      <h2>Contents</h2>
+      <ol>
+        {
+          chapters.map(({ post }, i) => (
+            <li>
+              <span class="toc-title">
+                {i + 1}. {post.data.title}
+              </span>
+              <span class="toc-date">{fmtDate(post.data.pubDate)}</span>
+            </li>
+          ))
+        }
+      </ol>
+    </nav>
+
+    {
+      chapters.map(({ post, Content }) => (
+        <article class="chapter">
+          <header>
+            <h2>{post.data.title}</h2>
+            <div class="chapter-date">{fmtDate(post.data.pubDate)}</div>
+          </header>
+          {
+            post.data.image && (
+              <figure class="hero-image">
+                <Image
+                  src={post.data.image}
+                  alt={post.data.alt || "Post hero image"}
+                  width={1200}
+                  height={600}
+                  quality={85}
+                  format="webp"
+                  fit="cover"
+                  position={post.data.imagePosition || "center"}
+                  loading="eager"
+                  decoding="sync"
+                />
+                {post.data.caption && (
+                  <figcaption>{post.data.caption}</figcaption>
+                )}
+              </figure>
+            )
+          }
+          <Content />
+        </article>
+      ))
+    }
+  </body>
+</html>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -43,7 +43,6 @@ export const GET: APIRoute = async ({ site }) => {
   const presentationFiles = [
     "presentations/2019-Feb-SLG.html",
     "presentations/2019-drupalcon-drupal-8-multisite.html",
-    "presentations/bundle-test.html",
     "presentations/drupal-intro.html",
     "presentations/drupal-multisite-on-a-dime.html",
     "presentations/tts-profile-mgmt.html",

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -52,7 +52,12 @@ export const GET: APIRoute = async ({ site }) => {
     "presentations/2026-02-22-squarespace-to-astro.html",
   ];
 
-  const urls = [...staticPages, ...postPages, ...presentationFiles];
+  // Downloadable archive artifact (the complete-archive PDF book). Indexable so
+  // the preservation copy is discoverable/crawlable. The /archive-book/ HTML page
+  // that generates it is noindex and intentionally NOT listed here.
+  const archiveFiles = ["blog-archive.pdf", "presentations-archive.pdf"];
+
+  const urls = [...staticPages, ...postPages, ...presentationFiles, ...archiveFiles];
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/tests/seo/sitemap.spec.ts
+++ b/tests/seo/sitemap.spec.ts
@@ -73,6 +73,12 @@ test.describe('Sitemap Validation', () => {
 			const presentationUrls = sitemapUrls.filter(url => url.includes('/presentations/') && url.endsWith('.html'));
 			expect(presentationUrls.length).toBeGreaterThan(5); // We have 8 presentation HTML files
 		});
+
+		test('includes archive PDF downloads', async () => {
+			const productionDomain = 'https://kyle.skrinak.com';
+			expect(sitemapUrls).toContain(`${productionDomain}/blog-archive.pdf`);
+			expect(sitemapUrls).toContain(`${productionDomain}/presentations-archive.pdf`);
+		});
 	});
 
 	test.describe('Pages that should NOT be in sitemap (noindex pages)', () => {

--- a/tests/seo/sitemap.spec.ts
+++ b/tests/seo/sitemap.spec.ts
@@ -149,9 +149,12 @@ test.describe('Sitemap Validation', () => {
 			});
 		});
 
-		test('all URLs have trailing slashes (except .html files)', async () => {
+		test('all URLs have trailing slashes (except file URLs with an extension)', async () => {
 			sitemapUrls.forEach(url => {
-				if (!url.endsWith('.html')) {
+				// Directory-style URLs must end in "/"; file URLs (a last path segment
+				// containing a ".", e.g. .html or .pdf) are exempt.
+				const lastSegment = url.split('/').pop() ?? '';
+				if (!lastSegment.includes('.')) {
 					expect(url.endsWith('/'), `Expected ${url} to have trailing slash`).toBeTruthy();
 				}
 			});


### PR DESCRIPTION
## Summary

Promotes the archive PDF feature from staging to production. Downloadable, self-contained PDF "books" of the blog and presentations, built in CI and served on-domain, untracked and backed by a per-environment GitHub Release.

## What's included

- **Archive PDF feature** — `/archive-book/` print page renders the full post archive to a 6×9in book; all standalone decks combine into one 16:9 landscape PDF with a linked TOC.
- **Untracked + release-backed store** — PDFs are gitignored; the `ensure-archive-pdfs` composite action hashes the rendering inputs, regenerates on change, otherwise downloads the existing release assets.
- **Build-first contract** — the ensure step runs after `build:ci`, rendering from the built `dist/` and writing the PDFs straight into `dist/` (no second `astro build`).
- **Per-env backing stores** — production uses the default tag `archive-pdfs`; staging uses `archive-pdfs-staging` (verified created on the staging deploy — no cross-env race).
- **Hash gate** covers all rendering inputs: content, presentations, `archive-book.astro`, selection/schema helpers (`getBlogPosts`, `postFilter`, `content.config.ts`), both build scripts, and `src/config`; excludes the `bundle-test.html` artifact.

## Review history (resolved on the develop→staging PR #229)

Five Copilot review rounds, all resolved: Pagefind indexing (rejected — opt-in, already excluded), bundle-test in sitemap/hash, build-first `dist/` clarifications, SEO trailing-slash test fix for `.pdf` URLs, `IgnoreInternalURLs` validity (rejected — verified valid empirically), hash selection inputs, and CLI flag validation.

## Verification (local)

- `npm run build && npm run check:links` pass with PDFs absent (htmltest `IgnoreInternalURLs` confirmed working).
- `npm run test:seo` passes (33 passed, 1 skipped).
- Both PDFs render from the built `dist/` via `--skip-build`; hash busts on content/selection changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
