### PR TITLE
chore(deps): promote astro 6.4.7 to production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,9 +3408,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.5.tgz",
-      "integrity": "sha512-0R7WLD1+WD/mTPcZxyKtcF0CztQi9ahFRtGM7oChJhxjNbr4lSBenxi+mk91k5bPTaUEoZ6edg1fDo2qP8bCwg==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
+      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",


### PR DESCRIPTION
## Summary

Promotes the Astro patch bump (`6.4.5 → 6.4.7`) to production.

Lockfile-only change within the existing `^6.3.8` range — patch-level bug fixes, none of the behavior-affecting items apply to this static site.

## Verification

- Local full gate against 6.4.7 (worktree): `npm ci` ✅, build ✅, `check:links` ✅ (0 broken), `test:visual` ✅ (no snapshot diffs).
- Green Renovate gates on the original #230: unit tests, npm signature verification, minimum release-age.
- Promoted through `develop → staging` (#232).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
