### PR TITLE
fix(content): validate contact email and URL schemes at build time

### DIFF
--- a/src/components/ResumeHeader.astro
+++ b/src/components/ResumeHeader.astro
@@ -31,7 +31,7 @@ const {
   linkedinAsUrl = false,
 } = Astro.props;
 
-const stripScheme = (url: string) => url.replace(/^https?:\/\//, "");
+const stripScheme = (url: string) => url.replace(/^https?:\/\//i, "");
 ---
 
 <div class="resume-header">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,9 +7,11 @@ export const BLOG_PATH = 'src/content/blog';
 // URL AND carry http(s) — z.string().url() alone accepts any parseable
 // scheme, javascript: included. Requiring a scheme is correct for these
 // always-absolute fields; the blocklist-over-allowlist rule applies to
-// fields that may hold relative URLs, which these never do.
+// fields that may hold relative URLs, which these never do. The protocol
+// check runs on the parsed URL, so scheme casing (HTTPS://) is handled per
+// RFC 3986; .url() has already guaranteed new URL() won't throw.
 const httpUrl = z.string().trim().url().refine(
-	(v) => /^https?:\/\//.test(v),
+	(v) => ['http:', 'https:'].includes(new URL(v).protocol),
 	{ message: 'Must be an absolute http(s) URL' },
 );
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,6 +3,16 @@ import { glob } from 'astro/loaders';
 
 export const BLOG_PATH = 'src/content/blog';
 
+// Absolute external link fields that feed href attributes: must parse as a
+// URL AND carry http(s) — z.string().url() alone accepts any parseable
+// scheme, javascript: included. Requiring a scheme is correct for these
+// always-absolute fields; the blocklist-over-allowlist rule applies to
+// fields that may hold relative URLs, which these never do.
+const httpUrl = z.string().trim().url().refine(
+	(v) => /^https?:\/\//.test(v),
+	{ message: 'Must be an absolute http(s) URL' },
+);
+
 const blog = defineCollection({
 	loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
 	schema: ({ image }) => z.object({
@@ -54,9 +64,11 @@ const pages = defineCollection({
 		toc: z.boolean().optional(),
 		image: image().optional(),
 		alt: z.string().trim().min(1).optional(),
-		contactEmail: z.string().trim().min(1).optional(),
-		contactWebsite: z.string().trim().min(1).optional(),
-		contactLinkedin: z.string().trim().min(1).optional(),
+		// Email/URL fields feed hrefs (mailto:, links) on both resume routes
+		// and the PDF — validate shape at build time (Copilot review, PR #242)
+		contactEmail: z.string().trim().email().optional(),
+		contactWebsite: httpUrl.optional(),
+		contactLinkedin: httpUrl.optional(),
 		contactAddress: z.string().trim().min(1).optional(),
 		current_role: z.object({
 			title: z.string().trim().min(1),


### PR DESCRIPTION
Addresses Copilot's PR #242 review comments 1–2: the resume contact fields feed `href` attributes on both resume routes and the PDF but accepted any non-empty string. `contactEmail` now validates as an email; `contactWebsite`/`contactLinkedin` require absolute http(s) URLs — `z.url()` alone accepts any parseable scheme (`javascript:` included), so the scheme refinement is the actual gate. Comment 3 (missing-baseline guard) was empirically refuted: the visual check passed on both promotion PRs and production has since regenerated the baseline.

Verified locally: a `javascript:` contactWebsite fails the build with the intended message (negative test); real content builds clean; eslint + config:validate pass.

Note: `content.config.ts` is a resume-PDF hash input, so the next deploy regenerates the PDF once — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)