### PR TITLE
Promote to main: cards directive attribute allowlist + dep bumps

### DIFF
--- a/docs/getting-started/creating-posts.md
+++ b/docs/getting-started/creating-posts.md
@@ -76,7 +76,7 @@ categories: ["astro", "blogging"]  # Optional: topic tags
 | `updatedDate` | `2026-01-20T00:00:00.000Z` | Last modified date (shows in post metadata; RSS pubDate refresh). |
 | `image` | `./my-image.webp` | Featured image. Also the default Open Graph card. |
 | `alt` | `"A screenshot of code"` | Accessibility text. **Required** when `image` or `heroImage` is set. |
-| `caption` | `"Screenshot of the homepage"` | Optional caption displayed below featured image. Accepts inline HTML (e.g. `<em>Title</em>`). |
+| `caption` | `"Screenshot of the homepage"` | Optional caption displayed below featured image. Accepts inline HTML (e.g. `<em>Title</em>`). Author-controlled only — do not put user-supplied content here. |
 | `ogImage` | `./social.webp` | Override: use different image for social sharing (defaults to `image`) |
 | `categories` | `["astro", "web"]` | Topic categories for filtering |
 | `tags` | `["astro", "tutorial"]` | Tags for filtering and discovery |
@@ -130,7 +130,7 @@ This is a paragraph. You can use **bold**, *italic*, or `code`.
 
 ## Card Grids
 
-Use the `:::cards` directive to render a responsive grid of cards. Cards are separated by `---` inside the block.
+Use the `:::cards` directive to render a responsive grid of cards. Cards are separated by `---` inside the block. Note: any `---` inside a card body is also treated as a card separator — thematic breaks cannot appear within card content.
 
 ```markdown
 :::cards{.testimonials}

--- a/docs/getting-started/creating-posts.md
+++ b/docs/getting-started/creating-posts.md
@@ -76,7 +76,7 @@ categories: ["astro", "blogging"]  # Optional: topic tags
 | `updatedDate` | `2026-01-20T00:00:00.000Z` | Last modified date (shows in post metadata; RSS pubDate refresh). |
 | `image` | `./my-image.webp` | Featured image. Also the default Open Graph card. |
 | `alt` | `"A screenshot of code"` | Accessibility text. **Required** when `image` or `heroImage` is set. |
-| `caption` | `"Screenshot of the homepage"` | Optional caption displayed below featured image. Accepts inline HTML (e.g. `<em>Title</em>`). Author-controlled only — do not put user-supplied content here. |
+| `caption` | `"Screenshot of the homepage"` | Optional caption displayed below featured image. Accepts inline HTML (e.g. `<em>Title</em>`) on individual post pages; other listing pages (e.g. the archive) render it as plain text and will show markup literally. Author-controlled only — do not put user-supplied content here. |
 | `ogImage` | `./social.webp` | Override: use different image for social sharing (defaults to `image`) |
 | `categories` | `["astro", "web"]` | Topic categories for filtering |
 | `tags` | `["astro", "tutorial"]` | Tags for filtering and discovery |

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@typescript-eslint/parser": "^8.59.4",
         "cross-env": "^10.1.0",
         "eslint": "^10.4.0",
-        "eslint-plugin-astro": "^2.1.1",
+        "eslint-plugin-astro": "^3.0.0",
         "github-slugger": "^2.0.0",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
@@ -2135,19 +2135,6 @@
         "win32"
       ]
     },
-    "node_modules/@pkgr/core": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
-      }
-    },
     "node_modules/@playwright/test": {
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
@@ -3812,22 +3799,20 @@
       }
     },
     "node_modules/astro-eslint-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-2.1.0.tgz",
-      "integrity": "sha512-poUfd66bOTY59rQajtusj/+i6kaBc4pKXkBa2XHYjwBZyhWThS1sdlgxLrnmo7NQqLUpvhmEtkOONUBs9WIp9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-3.0.0.tgz",
+      "integrity": "sha512-idgbHE8cjEU9f4Ne46RiGgwEviXYarNVoQoTZr+H1j7mbNCKp8EGGov2bR64/cvMpfBsX3XNPu9+muxAhK84eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^4.0.0",
+        "@astrojs/compiler-rs": "^0.3.1",
         "@typescript-eslint/scope-manager": "^8.61.0",
         "@typescript-eslint/types": "^8.61.0",
-        "astrojs-compiler-sync": "^1.0.0",
-        "debug": "^4.3.4",
-        "entities": "^8.0.0",
+        "debug": "^4.4.3",
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
         "espree": "^11.2.0",
-        "semver": "^7.3.8",
+        "semver": "^7.8.4",
         "tinyglobby": "^0.2.17"
       },
       "engines": {
@@ -3835,32 +3820,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/astro-eslint-parser/node_modules/@astrojs/compiler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
-      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/astrojs-compiler-sync": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
-      "integrity": "sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "synckit": "^0.11.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
-      },
-      "peerDependencies": {
-        "@astrojs/compiler": ">=0.27.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4772,19 +4731,18 @@
       }
     },
     "node_modules/eslint-plugin-astro": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-2.1.1.tgz",
-      "integrity": "sha512-oZwtjIfBOxOJT09exeGLQWy5o8/ATxY8RSq0548VMd0q7FqIVxoA5a46fRjnVLrj3pd3aP3/zkrGTuYPPo+iSw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-3.0.0.tgz",
+      "integrity": "sha512-wQv7uFZHuxN6QY1ynS9SJ0Wg41XE772rw0x9LSB4gzMixFYwSzMIXteUPLGdtaMI6ktZ227xFNnPw24HTwLJEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.5.1",
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@typescript-eslint/types": "^8.61.0",
-        "astro-eslint-parser": "^2.0.0",
+        "astro-eslint-parser": "^3.0.0",
         "espree": "^11.0.0",
         "globals": "^17.0.0",
-        "parse5": "^8.0.0",
         "postcss": "^8.5.3",
         "postcss-selector-parser": "^7.1.0"
       },
@@ -8294,19 +8252,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -9658,22 +9603,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/synckit": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.3.6"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@shikijs/transformers": "^4.1.0",
         "@tailwindcss/typography": "^0.5.19",
         "@types/lodash.kebabcase": "^4.1.9",
-        "@typescript-eslint/parser": "^8.59.4",
+        "@typescript-eslint/parser": "^8.61.0",
         "cross-env": "^10.1.0",
         "eslint": "^10.4.0",
         "eslint-plugin-astro": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8391,9 +8391,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5129,25 +5129,10 @@
         "xml-naming": "^0.3.0"
       }
     },
-    "node_modules/fast-xml-builder/node_modules/xml-naming": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
-      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/fast-xml-parser": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
-      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
+      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
       "funding": [
         {
           "type": "github",
@@ -5158,10 +5143,10 @@
       "dependencies": {
         "@nodable/entities": "^2.2.0",
         "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^1.0.1",
-        "path-expression-matcher": "^1.5.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
         "strnum": "^2.4.1",
-        "xml-naming": "^0.1.0"
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6041,9 +6026,9 @@
       }
     },
     "node_modules/is-unsafe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
-      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
       "funding": [
         {
           "type": "github",
@@ -10752,9 +10737,9 @@
       }
     },
     "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5114,9 +5114,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -5125,8 +5125,23 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-builder/node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fast-xml-parser": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/parser": "^8.59.4",
     "cross-env": "^10.1.0",
     "eslint": "^10.4.0",
-    "eslint-plugin-astro": "^2.1.1",
+    "eslint-plugin-astro": "^3.0.0",
     "github-slugger": "^2.0.0",
     "globals": "^17.6.0",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@shikijs/transformers": "^4.1.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/lodash.kebabcase": "^4.1.9",
-    "@typescript-eslint/parser": "^8.59.4",
+    "@typescript-eslint/parser": "^8.61.0",
     "cross-env": "^10.1.0",
     "eslint": "^10.4.0",
     "eslint-plugin-astro": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     "fast-xml-parser": "5.9.3",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.7",
-    "postcss": "8.5.16"
+    "postcss": "8.5.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "overrides": {
     "devalue": "5.8.1",
     "fast-uri": "4.1.0",
-    "fast-xml-builder": "1.2.0",
+    "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.9.3",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "devalue": "5.8.1",
     "fast-uri": "4.1.0",
     "fast-xml-builder": "1.3.0",
-    "fast-xml-parser": "5.9.3",
+    "fast-xml-parser": "5.10.0",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.7",
     "postcss": "8.5.19"

--- a/src/lib/remark-cards.mjs
+++ b/src/lib/remark-cards.mjs
@@ -79,11 +79,17 @@ export function remarkCards() {
         else groups[groups.length - 1].push(child);
       }
 
-      const { class: cls, ...rest } = node.attributes ?? {};
-      const variant = (cls ?? "").split(/\s+/).filter(Boolean);
+      const attrs = node.attributes ?? {};
+      const variant = (attrs.class ?? "").split(/\s+/).filter(Boolean);
+      // Allowlist safe passthrough attributes; block event handlers, style, etc.
+      const safeAttrs = Object.fromEntries(
+        Object.entries(attrs).filter(([k]) =>
+          k === "id" || k.startsWith("data-") || k.startsWith("aria-")
+        )
+      );
       node.data ??= {};
       node.data.hName = "div";
-      node.data.hProperties = { ...rest, className: ["card-row", ...variant] };
+      node.data.hProperties = { ...safeAttrs, className: ["card-row", ...variant] };
       node.children = groups.filter(g => g.length).map(buildCard);
     });
   };

--- a/tests/unit/remark-cards.test.mjs
+++ b/tests/unit/remark-cards.test.mjs
@@ -189,13 +189,14 @@ describe('remarkCards', () => {
 				style: 'background: url(javascript:alert(1))',
 				href: 'javascript:alert(1)',
 				src: 'x',
+				foo: 'bar',
 			},
 			[paragraph(text('one'))]
 		);
 		runPlugin({ type: 'root', children: [directive] });
 
 		const { hProperties } = directive.data;
-		for (const dangerous of ['onclick', 'onerror', 'style', 'href', 'src']) {
+		for (const dangerous of ['onclick', 'onerror', 'style', 'href', 'src', 'foo']) {
 			assert.ok(!(dangerous in hProperties), `expected "${dangerous}" to be stripped`);
 		}
 	});

--- a/tests/unit/remark-cards.test.mjs
+++ b/tests/unit/remark-cards.test.mjs
@@ -180,4 +180,45 @@ describe('remarkCards', () => {
 
 		assert.deepEqual(directive.data.hProperties.className, ['card-row', 'testimonials', 'wide']);
 	});
+
+	it('strips dangerous attributes (event handlers, style, arbitrary keys) from the directive', () => {
+		const directive = cardsDirective(
+			{
+				onclick: 'alert(1)',
+				onerror: 'alert(1)',
+				style: 'background: url(javascript:alert(1))',
+				href: 'javascript:alert(1)',
+				src: 'x',
+			},
+			[paragraph(text('one'))]
+		);
+		runPlugin({ type: 'root', children: [directive] });
+
+		const { hProperties } = directive.data;
+		for (const dangerous of ['onclick', 'onerror', 'style', 'href', 'src']) {
+			assert.ok(!(dangerous in hProperties), `expected "${dangerous}" to be stripped`);
+		}
+	});
+
+	it('passes id, data-*, and aria-* attributes through unchanged', () => {
+		const directive = cardsDirective(
+			{ id: 'featured', 'data-testid': 'cards-row', 'aria-label': 'Featured items' },
+			[paragraph(text('one'))]
+		);
+		runPlugin({ type: 'root', children: [directive] });
+
+		const { hProperties } = directive.data;
+		assert.equal(hProperties.id, 'featured');
+		assert.equal(hProperties['data-testid'], 'cards-row');
+		assert.equal(hProperties['aria-label'], 'Featured items');
+	});
+
+	it('does not let a dangerous key named "class" override the variant/className handling', () => {
+		const directive = cardsDirective({ class: 'wide', onmouseover: 'alert(1)' }, [paragraph(text('one'))]);
+		runPlugin({ type: 'root', children: [directive] });
+
+		const { hProperties } = directive.data;
+		assert.ok(!('onmouseover' in hProperties));
+		assert.deepEqual(hProperties.className, ['card-row', 'wide']);
+	});
 });


### PR DESCRIPTION
## Summary
- fix(cards): replace blind attribute spread in the `:::cards` remark directive with an explicit allowlist (`id`, `data-*`, `aria-*`), blocking event handlers/`style`/`href`/`src` passthrough into rendered HTML
- test(cards): regression tests for the allowlist, including arbitrary-key stripping
- docs: clarify `caption` frontmatter is author-controlled only, HTML rendering is page-dependent (post detail vs. archive), and cards `---` separator behavior
- chore(deps): bump `@typescript-eslint/parser` 8.59.4 → 8.61.0, `eslint-plugin-astro` 2.1.1 → 3.0.0, `fast-xml-parser`/`fast-xml-builder`/`postcss` (Renovate)

## Test plan
- [x] Unit tests: `tests/unit/remark-cards.test.mjs` (16/16 passing)
- [ ] `npm run build`
- [ ] `npm run test:visual`