### PR TITLE
Dependency patch bumps + link-check fix for tuitnutrition.com bot detection

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -20,6 +20,7 @@ IgnoreURLs:
   - "medium.com"  # Bot detection (403 to crawlers), works in real browsers
   - "ahajournals.org"  # Bot detection (403 to crawlers), works in real browsers
   - "manager-tools.com"  # Bot detection (403 to crawlers), works in real browsers
+  - "tuitnutrition.com"  # Bot detection — hangs Playwright (Chromium and WebKit, up to 60s), 0.4s in curl/real browsers
 IgnoreInternalURLs:
   # These PDFs are .gitignored and absent from a plain `npm run build`; the
   # deploy pipeline guarantees them via the ensure-release-pdfs action's

--- a/package-lock.json
+++ b/package-lock.json
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "funding": [
         {
           "type": "github",
@@ -5097,9 +5097,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
-      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -5108,7 +5108,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.2.0",
+        "@nodable/entities": "^3.0.0",
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^2.0.0",
         "path-expression-matcher": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5055,9 +5055,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
-      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4740,9 +4740,9 @@
       }
     },
     "node_modules/eslint-plugin-astro": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-3.0.0.tgz",
-      "integrity": "sha512-wQv7uFZHuxN6QY1ynS9SJ0Wg41XE772rw0x9LSB4gzMixFYwSzMIXteUPLGdtaMI6ktZ227xFNnPw24HTwLJEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-3.0.1.tgz",
+      "integrity": "sha512-skys0KV/5m/rQ6a4BDAGOGtrGoBlWNYiWtoDjx25bghDwTiKXng63s4Yv823iX3ht/tH/kHtoUM2poxESGsv3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8506,9 +8506,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
-      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.1.tgz",
+      "integrity": "sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8417,9 +8417,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "funding": [
         {
           "type": "opencollective",
@@ -8436,7 +8436,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "devalue": "5.8.1",
     "fast-uri": "4.1.0",
     "fast-xml-builder": "1.3.0",
-    "fast-xml-parser": "5.10.0",
+    "fast-xml-parser": "5.10.1",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.7",
     "postcss": "8.5.20"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "fast-xml-parser": "5.10.0",
     "flatted": "3.4.2",
     "brace-expansion": "5.0.7",
-    "postcss": "8.5.19"
+    "postcss": "8.5.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "overrides": {
     "devalue": "5.8.1",
-    "fast-uri": "4.1.0",
+    "fast-uri": "4.1.1",
     "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.10.1",
     "flatted": "3.4.2",


### PR DESCRIPTION
## Summary
- chore(deps): postcss 8.5.19 → 8.5.20 (#284)
- chore(deps): fast-xml-parser 5.10.0 → 5.10.1 (#283)
- chore(deps): fast-uri 4.1.0 → 4.1.1 (#281)
- chore(deps): dev-tools — eslint-plugin-astro 3.0.0→3.0.1, prettier-plugin-tailwindcss 0.8.0→0.8.1 (#280)
- fix(links): add tuitnutrition.com to .htmltest.yml IgnoreURLs (closes #282) — bot/fingerprint mitigation hangs Playwright regardless of engine or timeout length (tested Chromium/WebKit up to 60s); curl and real browsers reach it in <1s

## Test plan
- [x] `npm run build` — passes
- [x] `npm run check:links` — passes, tuitnutrition.com no longer flagged
- [x] `npm run test:visual:docker` (CI-matched Ubuntu environment) — 42/42 passed
- [x] Local `npm run test:visual` shows the known macOS-vs-Ubuntu font-rendering diffs on visual-desktop (already root-caused/fixed via baseline regen, unrelated to this change) — Docker run above is authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)