### PR TITLE
Add Webmention endpoint for production

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -23,6 +23,7 @@ IgnoreURLs:
   - "tuitnutrition.com"  # Bot detection — hangs Playwright (Chromium and WebKit, up to 60s), 0.4s in curl/real browsers
   - "xn--sr8hvo.ws/previous"  # Webring: 302s to random member sites; dead members would fail CI nondeterministically
   - "xn--sr8hvo.ws/next"  # Webring: 302s to random member sites; dead members would fail CI nondeterministically
+  - "webmention.io"  # Unclaimed until IndieAuth signup; also a POST-only receiver, so link-checker GET/HEAD requests will 4xx even once correctly configured
 IgnoreInternalURLs:
   # These PDFs are .gitignored and absent from a plain `npm run build`; the
   # deploy pipeline guarantees them via the ensure-release-pdfs action's

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,6 +46,7 @@ const {
 // ogImage must be root-relative (e.g. /og.png) or absolute — new URL() resolves
 // root-relative paths against the origin, ignoring the current page path.
 const socialImageURL = new URL(ogImage, Astro.url);
+const webmentionHostname = new URL(SITE.website).hostname;
 
 const deployEnv = PUBLIC_DEPLOY_ENV ?? "production";
 const isStaging = deployEnv === "staging";
@@ -86,6 +87,9 @@ const structuredData = {
     {/* Canonical link: tells search engines and tools where the "true" content lives.
         Can point to this page or to an external canonical URL via the canonicalURL prop. */}
     <link rel="canonical" href={canonicalURL} />
+    {!isStaging && (
+      <link rel="webmention" href={`https://webmention.io/${webmentionHostname}/webmention`} />
+    )}
     <meta name="generator" content={Astro.generator} />
 
     <!-- General Meta Tags -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -87,7 +87,7 @@ const structuredData = {
     {/* Canonical link: tells search engines and tools where the "true" content lives.
         Can point to this page or to an external canonical URL via the canonicalURL prop. */}
     <link rel="canonical" href={canonicalURL} />
-    {!isStaging && (
+    {import.meta.env.PROD && !isStaging && (
       <link rel="webmention" href={`https://webmention.io/${webmentionHostname}/webmention`} />
     )}
     <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
## Summary
Adds a functioning `<link rel="webmention">` tag so another blog's reply post can actually notify this site — currently there's no IndieWeb notification path at all. Endpoint wiring only (no display of received mentions); planned via Ultraplan and reviewed adversarially before implementation.

- Points at `https://webmention.io/kyle.skrinak.com/webmention`, hostname derived from `SITE.website` (no hardcoded domain duplication).
- Gated on `import.meta.env.PROD && !isStaging` — matches the existing pattern used for Google verification and Cloudflare analytics tags in the same layout, so it's excluded from local `astro dev` as well as staging, not just staging alone.
- Adds `webmention.io` to `.htmltest.yml`'s `IgnoreURLs` — its endpoint is POST-only and unclaimed until sign-up, so a link-checker's GET/HEAD would 4xx regardless of correct setup.
- No `rel="pingback"` tag included — its URL format couldn't be independently verified during planning, so it's deferred until confirmed from the webmention.io account dashboard, if wanted.

Already reviewed and merged via #302 (develop → staging), including a Copilot-flagged fix for the PROD gating.

Next step (manual, outside this PR): the user signs in to webmention.io to claim `kyle.skrinak.com`. Nothing on the live site changes visually — received mentions are only visible via webmention.io's own dashboard, per the endpoint-only scope.

## Test plan
- [x] `npm run build` passes; verified the tag renders correctly in a production-mode build and is correctly absent in a staging-mode build
- [x] `npm run check:links` passes (webmention.io ignored as intended)
- [x] `npm run test:visual:docker` (Linux-matched, same image as CI) — 42/42 pass cleanly against the committed baselines, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)