### PR TITLE
feat: display received webmentions on blog posts (wraps up #261)

### DIFF
--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -32,10 +32,23 @@
     "bookmark-of": "bookmarked this",
   };
 
+  // Webmention payloads are submitted by third parties — never trust a URL
+  // field enough to assign it directly to href/src (javascript:/data: schemes).
+  function safeHttpUrl(url: string | undefined): string | undefined {
+    if (!url) return undefined;
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   function createAvatar(author: WebmentionAuthor | undefined): HTMLImageElement | null {
-    if (!author?.photo) return null;
+    const safePhoto = safeHttpUrl(author?.photo);
+    if (!safePhoto) return null;
     const img = document.createElement("img");
-    img.src = author.photo;
+    img.src = safePhoto;
     img.alt = "";
     img.width = 24;
     img.height = 24;
@@ -46,9 +59,10 @@
 
   function createNameLink(author: WebmentionAuthor | undefined): HTMLElement {
     const name = author?.name?.trim() || "Someone";
-    if (author?.url) {
+    const safeUrl = safeHttpUrl(author?.url);
+    if (safeUrl) {
       const link = document.createElement("a");
-      link.href = author.url;
+      link.href = safeUrl;
       link.className = "text-accent hover:underline";
       link.textContent = name;
       return link;
@@ -71,11 +85,21 @@
     const wmProperty = entry["wm-property"];
 
     if (wmProperty && LIKE_TYPES.has(wmProperty)) {
-      const line = document.createElement("a");
-      line.href = entry.url;
-      line.className = "hover:underline";
-      line.appendChild(nameLink.cloneNode(true));
-      line.append(` ${VERB_BY_TYPE[wmProperty]}`);
+      // Two sibling elements (name link + verb link), not nested anchors.
+      const line = document.createElement("p");
+      line.appendChild(nameLink);
+      const verb = VERB_BY_TYPE[wmProperty];
+      const safeEntryUrl = safeHttpUrl(entry.url);
+      line.append(" ");
+      if (safeEntryUrl) {
+        const verbLink = document.createElement("a");
+        verbLink.href = safeEntryUrl;
+        verbLink.className = "hover:underline";
+        verbLink.textContent = verb;
+        line.appendChild(verbLink);
+      } else {
+        line.append(verb);
+      }
       body.appendChild(line);
     } else {
       body.appendChild(nameLink);
@@ -99,7 +123,9 @@
     container.dataset.initialized = "true";
 
     try {
-      const target = window.location.href;
+      // Strip query string/hash — webmention.io matches on the canonical page
+      // URL, and heading permalinks (#some-heading) would otherwise mismatch it.
+      const target = `${window.location.origin}${window.location.pathname}`;
       const response = await fetch(
         `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}`
       );

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -1,0 +1,130 @@
+<div id="webmentions"></div>
+
+<script>
+  interface WebmentionAuthor {
+    name?: string;
+    url?: string;
+    photo?: string;
+  }
+
+  interface WebmentionEntry {
+    type: string;
+    author?: WebmentionAuthor;
+    url: string;
+    published?: string;
+    "wm-received"?: string;
+    "wm-id"?: number;
+    content?: { text?: string; html?: string };
+    "wm-property"?: string;
+  }
+
+  interface WebmentionFeed {
+    type: string;
+    name: string;
+    children: WebmentionEntry[];
+  }
+
+  const LIKE_TYPES = new Set(["like-of", "repost-of", "bookmark-of"]);
+
+  const VERB_BY_TYPE: Record<string, string> = {
+    "like-of": "liked this",
+    "repost-of": "reposted this",
+    "bookmark-of": "bookmarked this",
+  };
+
+  function createAvatar(author: WebmentionAuthor | undefined): HTMLImageElement | null {
+    if (!author?.photo) return null;
+    const img = document.createElement("img");
+    img.src = author.photo;
+    img.alt = "";
+    img.width = 24;
+    img.height = 24;
+    img.loading = "lazy";
+    img.className = "size-6 flex-none rounded-full";
+    return img;
+  }
+
+  function createNameLink(author: WebmentionAuthor | undefined): HTMLElement {
+    const name = author?.name?.trim() || "Someone";
+    if (author?.url) {
+      const link = document.createElement("a");
+      link.href = author.url;
+      link.className = "text-accent hover:underline";
+      link.textContent = name;
+      return link;
+    }
+    const span = document.createElement("span");
+    span.textContent = name;
+    return span;
+  }
+
+  function createEntryItem(entry: WebmentionEntry): HTMLLIElement {
+    const li = document.createElement("li");
+    li.className = "flex items-start gap-2 text-sm opacity-80";
+
+    const avatar = createAvatar(entry.author);
+    if (avatar) li.appendChild(avatar);
+
+    const body = document.createElement("div");
+
+    const nameLink = createNameLink(entry.author);
+    const wmProperty = entry["wm-property"];
+
+    if (wmProperty && LIKE_TYPES.has(wmProperty)) {
+      const line = document.createElement("a");
+      line.href = entry.url;
+      line.className = "hover:underline";
+      line.appendChild(nameLink.cloneNode(true));
+      line.append(` ${VERB_BY_TYPE[wmProperty]}`);
+      body.appendChild(line);
+    } else {
+      body.appendChild(nameLink);
+      const snippet = entry.content?.text?.trim();
+      if (snippet) {
+        const p = document.createElement("p");
+        p.className = "mt-0.5";
+        p.textContent = snippet.length > 200 ? `${snippet.slice(0, 200)}…` : snippet;
+        body.appendChild(p);
+      }
+    }
+
+    li.appendChild(body);
+    return li;
+  }
+
+  async function initWebmentions() {
+    const container = document.getElementById("webmentions");
+    if (!container) return;
+    if (container.dataset.initialized === "true") return;
+    container.dataset.initialized = "true";
+
+    try {
+      const target = window.location.href;
+      const response = await fetch(
+        `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}`
+      );
+      if (!response.ok) return;
+
+      const feed = (await response.json()) as WebmentionFeed;
+      if (!feed.children || feed.children.length === 0) return;
+
+      const heading = document.createElement("span");
+      heading.className = "italic";
+      heading.textContent = "Mentions";
+
+      const list = document.createElement("ul");
+      list.className = "mt-2 flex flex-col gap-3";
+      for (const entry of feed.children) {
+        list.appendChild(createEntryItem(entry));
+      }
+
+      container.appendChild(heading);
+      container.appendChild(list);
+    } catch {
+      // Network/CORS failure — treat identically to "no mentions" (silent no-op).
+    }
+  }
+
+  document.addEventListener("astro:page-load", initWebmentions);
+  initWebmentions();
+</script>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -8,6 +8,7 @@ import Tag from "@/components/Tag.astro";
 import Datetime from "@/components/Datetime.astro";
 import EditPost from "@/components/EditPost.astro";
 import ShareLinks from "@/components/ShareLinks.astro";
+import Webmentions from "@/components/Webmentions.astro";
 import BackButton from "@/components/BackButton.astro";
 import BackToTopButton from "@/components/BackToTopButton.astro";
 import { getPath } from "@/utils/getPath";
@@ -168,6 +169,8 @@ const nextPost =
     <BackToTopButton />
 
     <ShareLinks />
+
+    <Webmentions />
 
     <hr class="my-6 border-dashed" />
 


### PR DESCRIPTION
## Description

Adds a `Webmentions` component that fetches webmention.io's public JF2 API client-side for the current post URL and renders received likes, reposts, bookmarks, and reply/mention snippets at the bottom of each blog post. Implements requirement 2 of #261 (requirement 1, the `<link rel="webmention">` endpoint tag, already shipped via PR #302/#303) and resolves the issue's open fetching-strategy question in favor of its own recommendation: client-side fetching, since it needs no build-time infrastructure and the API requires no auth key.

## Type of Change

- [x] Feature (non-breaking change which adds functionality)

## Checklist

### Code Quality
- [x] Code follows project conventions (ESLint, TypeScript, Prettier) — `npm run lint` and `npm run format:check` show no new issues from this change.
- [x] No hardcoded secrets, tokens, or sensitive data.
- [x] Type safety: no `@ts-ignore`; `wm-property`/`content`/`author` fields are typed as optional since webmention.io's own docs don't guarantee `wm-property` on every entry.
- [x] No complex logic requiring comments beyond the one clarifying the CORS/empty-state fallback.

### Testing & Validation
- [x] Local build succeeds: `npm run build`.
- [x] `astro check` passes with 0 errors (pre-existing zod-deprecation warnings only, unrelated to this change).
- [x] Visual regression tests pass on the Chromium-based projects (`visual-desktop`, including the individual/mobile blog post specs) — 21/21 passed, no diffs.
- [ ] `npm run check:links` — not run; this sandbox's network access is scoped to this repo only and can't fetch the `htmltest` binary from `wjdp/htmltest`. No new static links were introduced (the fetch URL lives inside a `<script>`, not an `<a href>`), and `webmention.io` is already in `.htmltest.yml`'s `IgnoreURLs`.
- [x] Console errors checked — component fails silently (no `console.error`/`console.warn`) on empty results or fetch/CORS failure, matching `tests/console-errors.spec.ts` expectations.
- [x] Local preview works — verified via a headless Chromium check against `astro preview`: the client script fires a `GET` to `webmention.io/api/mentions.jf2?target=<page URL>` on page load and the container stays empty (no visible output, no thrown errors) when the request can't complete.
- [ ] CI passes on this branch — pending, will confirm once GitHub Actions run.

### Documentation & Changelog
- [ ] `CHANGELOG.md` — not updated; project has no evidence of a maintained changelog convention for component-level changes (none of the sibling components have entries).

### Security & Performance
- [x] No new dependencies.
- [x] No hardcoded API endpoint beyond what `Layout.astro` already hardcodes for the webmention endpoint tag (`webmention.io`); no new config/env needed.
- [x] Avatar `<img>` elements set explicit `width`/`height` to avoid CLS, per the project's image-performance rule.

## Related Issues

Closes #261

## Additional Context

- Two known, pre-existing limitations documented for reviewers rather than fixed here: (1) webmention.io's JF2 API has an open upstream issue (aaronpk/webmention.io#153) where Firefox/Safari can hit CORS failures on this endpoint even though Chrome works — this repo's own Playwright suite only runs Desktop Chrome, so it won't surface here, and our silent-failure design degrades gracefully either way. (2) `develop`/`staging` are currently one merge commit behind `main` (PR #303) — unrelated housekeeping, flagged separately, not part of this PR.
- The populated-mentions rendering path (avatars, names, type-specific text) could not be verified against a live post with existing webmentions from this sandbox, since kyle.skrinak.com isn't yet claimed on webmention.io and outbound network access here is otherwise restricted. Recommend a manual check against a real post with mentions before/after merging to staging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjkNNRBTM83WbKcdgdsy3X)_