### PR TITLE
Display received webmentions on blog posts

### DIFF
--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -32,20 +32,43 @@
     "bookmark-of": "bookmarked this",
   };
 
+  // Some entries only populate content.html, not content.text. DOMParser's
+  // output is never inserted into the live document — only .textContent is
+  // read from it — so this safely extracts plain text without risking the
+  // untrusted markup executing or being rendered.
+  function extractSnippet(content: { text?: string; html?: string } | undefined): string | undefined {
+    const text = content?.text?.trim();
+    if (text) return text;
+    const html = content?.html?.trim();
+    if (!html) return undefined;
+    const parsed = new DOMParser().parseFromString(html, "text/html").body.textContent?.trim();
+    return parsed || undefined;
+  }
+
   // Webmention payloads are submitted by third parties — never trust a URL
   // field enough to assign it directly to href/src (javascript:/data: schemes).
-  function safeHttpUrl(url: string | undefined): string | undefined {
+  // `base` resolves relative/scheme-relative URLs (e.g. a sender's h-card
+  // photo given relative to their own page) against that source page,
+  // rather than rejecting anything that isn't already absolute; the
+  // protocol check still runs on the resolved result, so an explicitly
+  // absolute "javascript:" URL is rejected regardless of base.
+  function safeHttpUrl(url: string | undefined, base?: string): string | undefined {
     if (!url) return undefined;
     try {
-      const parsed = new URL(url);
-      return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : undefined;
+      const parsed = new URL(url, base);
+      return parsed.protocol === "http:" || parsed.protocol === "https:"
+        ? parsed.href
+        : undefined;
     } catch {
       return undefined;
     }
   }
 
-  function createAvatar(author: WebmentionAuthor | undefined): HTMLImageElement | null {
-    const safePhoto = safeHttpUrl(author?.photo);
+  function createAvatar(
+    author: WebmentionAuthor | undefined,
+    base: string
+  ): HTMLImageElement | null {
+    const safePhoto = safeHttpUrl(author?.photo, base);
     if (!safePhoto) return null;
     const img = document.createElement("img");
     img.src = safePhoto;
@@ -53,13 +76,14 @@
     img.width = 24;
     img.height = 24;
     img.loading = "lazy";
+    img.referrerPolicy = "no-referrer";
     img.className = "size-6 flex-none rounded-full";
     return img;
   }
 
-  function createNameLink(author: WebmentionAuthor | undefined): HTMLElement {
+  function createNameLink(author: WebmentionAuthor | undefined, base: string): HTMLElement {
     const name = author?.name?.trim() || "Someone";
-    const safeUrl = safeHttpUrl(author?.url);
+    const safeUrl = safeHttpUrl(author?.url, base);
     if (safeUrl) {
       const link = document.createElement("a");
       link.href = safeUrl;
@@ -76,12 +100,12 @@
     const li = document.createElement("li");
     li.className = "flex items-start gap-2 text-sm opacity-80";
 
-    const avatar = createAvatar(entry.author);
+    const avatar = createAvatar(entry.author, entry.url);
     if (avatar) li.appendChild(avatar);
 
     const body = document.createElement("div");
 
-    const nameLink = createNameLink(entry.author);
+    const nameLink = createNameLink(entry.author, entry.url);
     const wmProperty = entry["wm-property"];
 
     if (wmProperty && LIKE_TYPES.has(wmProperty)) {
@@ -103,7 +127,7 @@
       body.appendChild(line);
     } else {
       body.appendChild(nameLink);
-      const snippet = entry.content?.text?.trim();
+      const snippet = extractSnippet(entry.content);
       if (snippet) {
         const p = document.createElement("p");
         p.className = "mt-0.5";

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -32,10 +32,23 @@
     "bookmark-of": "bookmarked this",
   };
 
+  // Webmention payloads are submitted by third parties — never trust a URL
+  // field enough to assign it directly to href/src (javascript:/data: schemes).
+  function safeHttpUrl(url: string | undefined): string | undefined {
+    if (!url) return undefined;
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   function createAvatar(author: WebmentionAuthor | undefined): HTMLImageElement | null {
-    if (!author?.photo) return null;
+    const safePhoto = safeHttpUrl(author?.photo);
+    if (!safePhoto) return null;
     const img = document.createElement("img");
-    img.src = author.photo;
+    img.src = safePhoto;
     img.alt = "";
     img.width = 24;
     img.height = 24;
@@ -46,9 +59,10 @@
 
   function createNameLink(author: WebmentionAuthor | undefined): HTMLElement {
     const name = author?.name?.trim() || "Someone";
-    if (author?.url) {
+    const safeUrl = safeHttpUrl(author?.url);
+    if (safeUrl) {
       const link = document.createElement("a");
-      link.href = author.url;
+      link.href = safeUrl;
       link.className = "text-accent hover:underline";
       link.textContent = name;
       return link;
@@ -71,11 +85,21 @@
     const wmProperty = entry["wm-property"];
 
     if (wmProperty && LIKE_TYPES.has(wmProperty)) {
-      const line = document.createElement("a");
-      line.href = entry.url;
-      line.className = "hover:underline";
-      line.appendChild(nameLink.cloneNode(true));
-      line.append(` ${VERB_BY_TYPE[wmProperty]}`);
+      // Two sibling elements (name link + verb link), not nested anchors.
+      const line = document.createElement("p");
+      line.appendChild(nameLink);
+      const verb = VERB_BY_TYPE[wmProperty];
+      const safeEntryUrl = safeHttpUrl(entry.url);
+      line.append(" ");
+      if (safeEntryUrl) {
+        const verbLink = document.createElement("a");
+        verbLink.href = safeEntryUrl;
+        verbLink.className = "hover:underline";
+        verbLink.textContent = verb;
+        line.appendChild(verbLink);
+      } else {
+        line.append(verb);
+      }
       body.appendChild(line);
     } else {
       body.appendChild(nameLink);
@@ -99,7 +123,9 @@
     container.dataset.initialized = "true";
 
     try {
-      const target = window.location.href;
+      // Strip query string/hash — webmention.io matches on the canonical page
+      // URL, and heading permalinks (#some-heading) would otherwise mismatch it.
+      const target = `${window.location.origin}${window.location.pathname}`;
       const response = await fetch(
         `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}`
       );

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -1,0 +1,130 @@
+<div id="webmentions"></div>
+
+<script>
+  interface WebmentionAuthor {
+    name?: string;
+    url?: string;
+    photo?: string;
+  }
+
+  interface WebmentionEntry {
+    type: string;
+    author?: WebmentionAuthor;
+    url: string;
+    published?: string;
+    "wm-received"?: string;
+    "wm-id"?: number;
+    content?: { text?: string; html?: string };
+    "wm-property"?: string;
+  }
+
+  interface WebmentionFeed {
+    type: string;
+    name: string;
+    children: WebmentionEntry[];
+  }
+
+  const LIKE_TYPES = new Set(["like-of", "repost-of", "bookmark-of"]);
+
+  const VERB_BY_TYPE: Record<string, string> = {
+    "like-of": "liked this",
+    "repost-of": "reposted this",
+    "bookmark-of": "bookmarked this",
+  };
+
+  function createAvatar(author: WebmentionAuthor | undefined): HTMLImageElement | null {
+    if (!author?.photo) return null;
+    const img = document.createElement("img");
+    img.src = author.photo;
+    img.alt = "";
+    img.width = 24;
+    img.height = 24;
+    img.loading = "lazy";
+    img.className = "size-6 flex-none rounded-full";
+    return img;
+  }
+
+  function createNameLink(author: WebmentionAuthor | undefined): HTMLElement {
+    const name = author?.name?.trim() || "Someone";
+    if (author?.url) {
+      const link = document.createElement("a");
+      link.href = author.url;
+      link.className = "text-accent hover:underline";
+      link.textContent = name;
+      return link;
+    }
+    const span = document.createElement("span");
+    span.textContent = name;
+    return span;
+  }
+
+  function createEntryItem(entry: WebmentionEntry): HTMLLIElement {
+    const li = document.createElement("li");
+    li.className = "flex items-start gap-2 text-sm opacity-80";
+
+    const avatar = createAvatar(entry.author);
+    if (avatar) li.appendChild(avatar);
+
+    const body = document.createElement("div");
+
+    const nameLink = createNameLink(entry.author);
+    const wmProperty = entry["wm-property"];
+
+    if (wmProperty && LIKE_TYPES.has(wmProperty)) {
+      const line = document.createElement("a");
+      line.href = entry.url;
+      line.className = "hover:underline";
+      line.appendChild(nameLink.cloneNode(true));
+      line.append(` ${VERB_BY_TYPE[wmProperty]}`);
+      body.appendChild(line);
+    } else {
+      body.appendChild(nameLink);
+      const snippet = entry.content?.text?.trim();
+      if (snippet) {
+        const p = document.createElement("p");
+        p.className = "mt-0.5";
+        p.textContent = snippet.length > 200 ? `${snippet.slice(0, 200)}…` : snippet;
+        body.appendChild(p);
+      }
+    }
+
+    li.appendChild(body);
+    return li;
+  }
+
+  async function initWebmentions() {
+    const container = document.getElementById("webmentions");
+    if (!container) return;
+    if (container.dataset.initialized === "true") return;
+    container.dataset.initialized = "true";
+
+    try {
+      const target = window.location.href;
+      const response = await fetch(
+        `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}`
+      );
+      if (!response.ok) return;
+
+      const feed = (await response.json()) as WebmentionFeed;
+      if (!feed.children || feed.children.length === 0) return;
+
+      const heading = document.createElement("span");
+      heading.className = "italic";
+      heading.textContent = "Mentions";
+
+      const list = document.createElement("ul");
+      list.className = "mt-2 flex flex-col gap-3";
+      for (const entry of feed.children) {
+        list.appendChild(createEntryItem(entry));
+      }
+
+      container.appendChild(heading);
+      container.appendChild(list);
+    } catch {
+      // Network/CORS failure — treat identically to "no mentions" (silent no-op).
+    }
+  }
+
+  document.addEventListener("astro:page-load", initWebmentions);
+  initWebmentions();
+</script>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -8,6 +8,7 @@ import Tag from "@/components/Tag.astro";
 import Datetime from "@/components/Datetime.astro";
 import EditPost from "@/components/EditPost.astro";
 import ShareLinks from "@/components/ShareLinks.astro";
+import Webmentions from "@/components/Webmentions.astro";
 import BackButton from "@/components/BackButton.astro";
 import BackToTopButton from "@/components/BackToTopButton.astro";
 import { getPath } from "@/utils/getPath";
@@ -168,6 +169,8 @@ const nextPost =
     <BackToTopButton />
 
     <ShareLinks />
+
+    <Webmentions />
 
     <hr class="my-6 border-dashed" />
 


### PR DESCRIPTION
## Summary
Wraps up issue #261 (requirement 2 — requirement 1, the `<link rel="webmention">` endpoint tag, already shipped via #302/#303). Implemented via Ultraplan (PR #304), hardened per Copilot review across two rounds (PR #305, this PR), and independently verified against real webmention.io data before promoting.

- New `Webmentions.astro` component: client-side fetch against webmention.io's public JF2 API for the current post's URL (query/hash stripped), rendering avatars/names for likes/reposts/bookmarks and reply/mention snippets. Resolves the issue's own open "fetching strategy" question in favor of client-side, per its own recommendation.
- Silently no-ops on empty results or fetch/CORS failure — required behavior ("show nothing when a post has no mentions").
- Hardened against untrusted third-party feed data: DOM built via `createElement`/`textContent` (no `innerHTML`); a `safeHttpUrl` guard rejects `javascript:`/`data:` schemes and resolves relative/scheme-relative URLs against the sending page; a `content.html`-via-`DOMParser` fallback for entries missing `content.text` (parsed output never touches the live DOM); avatar `<img>` elements set `referrerPolicy="no-referrer"`; author and verb links carry `rel="nofollow ugc"` since both point at attacker-controlled URLs, guarding against SEO-spam webmentions farming followed backlinks; `LIKE_TYPES` is now derived from `VERB_BY_TYPE`'s own keys instead of a separately maintained duplicate list.
- Slots into `PostDetails.astro` right after `<ShareLinks />`.

## Test plan
- [x] `npm run build` passes
- [x] `npm run check:links` passes
- [x] `npm run test:visual:docker` (Linux-matched, same image as CI) — 42/42 pass, no diff (matches the real-world empty state today, since kyle.skrinak.com isn't yet claimed on webmention.io)
- [x] Verified the *populated* rendering path in a real browser against real webmention.io data — `https://adactio.com/` (real `like-of` entry) and `https://tantek.com/` (real `in-reply-to`/`mention-of` entries with names, photos, content snippets) — both code paths, plus `rel="nofollow ugc"` presence, confirmed correct after each round of fixes, then reverted the temporary test target before each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)