### PR TITLE
Fix: ship the PR #306 Copilot review fix that missed staging

### DIFF
--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -24,13 +24,15 @@
     children: WebmentionEntry[];
   }
 
-  const LIKE_TYPES = new Set(["like-of", "repost-of", "bookmark-of"]);
-
   const VERB_BY_TYPE: Record<string, string> = {
     "like-of": "liked this",
     "repost-of": "reposted this",
     "bookmark-of": "bookmarked this",
   };
+
+  // Derived from VERB_BY_TYPE's own keys rather than a separately maintained
+  // list, so the two can't drift out of sync.
+  const LIKE_TYPES = new Set(Object.keys(VERB_BY_TYPE));
 
   // Some entries only populate content.html, not content.text. DOMParser's
   // output is never inserted into the live document — only .textContent is
@@ -87,6 +89,7 @@
     if (safeUrl) {
       const link = document.createElement("a");
       link.href = safeUrl;
+      link.rel = "nofollow ugc";
       link.className = "text-accent hover:underline";
       link.textContent = name;
       return link;
@@ -118,6 +121,7 @@
       if (safeEntryUrl) {
         const verbLink = document.createElement("a");
         verbLink.href = safeEntryUrl;
+        verbLink.rel = "nofollow ugc";
         verbLink.className = "hover:underline";
         verbLink.textContent = verb;
         line.appendChild(verbLink);


### PR DESCRIPTION
## Summary
Process fix: when addressing Copilot's review comments on PR #306 (staging→main), I mistakenly committed the fix to `develop` instead of `staging` — this project's convention is that staging→main PR fixes go directly to `staging`. As a result, PR #306 merged to `main` without that fix ever being part of it, even though the review threads showed as resolved.

This PR carries the missing fix (`fa10ae1`, already reviewed/resolved on #306) into `main` via a reconciliation merge (`67e4b3f`, `develop` → `staging`), since `staging`/`main` had already advanced past the point where a simple fast-forward or cherry-pick would apply cleanly.

**The actual code fix** (unchanged from what was already reviewed on #306):
- `LIKE_TYPES` now derives from `VERB_BY_TYPE`'s own keys instead of a separately maintained duplicate list.
- `rel="nofollow ugc"` added to author-name links and like/repost verb links in `Webmentions.astro` — both point at attacker-controlled URLs, guarding against SEO-spam webmentions farming followed backlinks.

## Test plan
- [x] `npx tsc --noEmit` passes on the merged `staging` state
- [x] `npm run build` passes on the merged `staging` state
- [x] Content of `Webmentions.astro` manually diffed post-merge — confirms both fixes present, nothing else changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)