### PR TITLE
Align check-live-weight.mjs with 512KB Club's endorsed DebugBear tool

### DIFF
--- a/scripts/check-live-weight.mjs
+++ b/scripts/check-live-weight.mjs
@@ -119,15 +119,19 @@ async function collectDeclaredIconResources(page, alreadyCapturedUrls) {
   }
 
   const results = [];
-  for (const iconUrl of candidateUrls) {
-    if (alreadyCapturedUrls.has(iconUrl)) continue;
+  for (const candidateUrl of candidateUrls) {
+    if (alreadyCapturedUrls.has(candidateUrl)) continue;
     try {
-      const res = await fetch(iconUrl, { headers: { 'Accept-Encoding': 'identity' } });
+      const res = await fetch(candidateUrl, { headers: { 'Accept-Encoding': 'identity' } });
       if (!res.ok) continue; // e.g. no favicon.ico at this path
       const buffer = await res.arrayBuffer();
+      const type =
+        candidateUrl === manifestUrl
+          ? 'Manifest (declared, not organically fetched)'
+          : 'Icon (declared, not organically fetched)';
       results.push({
-        url: iconUrl,
-        type: 'Icon (declared, not organically fetched)',
+        url: candidateUrl,
+        type,
         bytes: buffer.byteLength,
         transferBytes: buffer.byteLength,
       });

--- a/scripts/check-live-weight.mjs
+++ b/scripts/check-live-weight.mjs
@@ -7,10 +7,24 @@
  * load — first-party assets AND third-party resources (analytics, tag
  * managers, etc.) that only exist once the page executes client-side JS.
  * This uses the 512 KiB figure popularized by the 512KB Club as a round-
- * number budget; the club's own methodology measures uncompressed size via
- * the Cloudflare URL Scanner, so this script gates on decoded bytes to
- * match. Transfer (compressed) bytes are also reported for comparison with
- * DebugBear-style tools, which report transfer size.
+ * number budget; the club's own FAQ designates DebugBear's Page Size
+ * Checker (debugbear.com/test/page-size-checker) as the tool to verify
+ * against, and its "Full Size" column (uncompressed) is the metric that
+ * matches the club's stated rule — its default "Size" column is transfer
+ * bytes and reads much lower. This script gates on decoded bytes to match
+ * that Full Size figure. Transfer (compressed) bytes are also reported.
+ *
+ * Playwright's Chromium — headless or headed — does not organically fetch
+ * favicon/manifest-icon links the way DebugBear's own test does (confirmed
+ * empirically: neither mode requested favicon.ico, apple-touch-icon.png,
+ * site.webmanifest, or the manifest's icon files during a real cold load
+ * of this site). Rather than depend on unreliable browser-internal
+ * heuristics to coax those fetches, collectDeclaredIconResources() fetches
+ * favicon.ico, the manifest file, and only the smallest manifest icon —
+ * matching (by manual comparison) what DebugBear's own real-browser test
+ * captured for this site, rather than exhaustively counting every declared
+ * icon variant (apple-touch-icon, alternate favicon sizes, every manifest
+ * size), which real page loads don't actually fetch.
  *
  * Unlike scripts/check-size.mjs (removed), this is NOT a build-time gate —
  * it can only run against a live, deployed site, so it's a nightly,
@@ -63,6 +77,67 @@ function errorMessage(err) {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Scoped to match what DebugBear's real-browser Page Size Checker actually
+// captured for this site (verified manually): favicon.ico, the manifest
+// file itself, and only the smallest manifest icon — not every declared
+// variant. Real browsers pick one "best" icon per purpose rather than
+// fetching apple-touch-icon.png, alternate favicon sizes, or every manifest
+// icon size; counting all of them (an earlier version of this function)
+// overshoots what any real page load actually costs. Requests
+// Accept-Encoding: identity so the byte count is the exact decoded size
+// with no ambiguity from this script's own fetch() transparently
+// decompressing an encoded response.
+async function collectDeclaredIconResources(page, alreadyCapturedUrls) {
+  const manifestUrl = await page.evaluate(() => {
+    const link = document.querySelector('link[rel="manifest"]');
+    return link?.href ?? null;
+  });
+
+  const candidateUrls = new Set();
+  candidateUrls.add(new URL('/favicon.ico', page.url()).href);
+  if (manifestUrl) candidateUrls.add(manifestUrl);
+
+  if (manifestUrl) {
+    try {
+      const res = await fetch(manifestUrl, { headers: { 'Accept-Encoding': 'identity' } });
+      const manifest = await res.json();
+      // Only consider entries with an explicit purpose ("any"/"maskable") —
+      // real PWA icon candidates — not a bare favicon-fallback entry with no
+      // purpose field (this manifest lists one at 96x96 that real browsers
+      // don't treat as an installable icon). Pick the smallest of those,
+      // matching the one icon DebugBear's real-browser test fetched.
+      const installableIcons = (manifest.icons ?? []).filter(icon => icon.purpose);
+      const smallest = installableIcons.reduce((min, icon) => {
+        const width = Number.parseInt(icon.sizes?.split('x')[0], 10) || Infinity;
+        const minWidth = min ? Number.parseInt(min.sizes?.split('x')[0], 10) || Infinity : Infinity;
+        return width < minWidth ? icon : min;
+      }, null);
+      if (smallest?.src) candidateUrls.add(new URL(smallest.src, manifestUrl).href);
+    } catch {
+      // Manifest fetch/parse failure shouldn't block the rest of the report.
+    }
+  }
+
+  const results = [];
+  for (const iconUrl of candidateUrls) {
+    if (alreadyCapturedUrls.has(iconUrl)) continue;
+    try {
+      const res = await fetch(iconUrl, { headers: { 'Accept-Encoding': 'identity' } });
+      if (!res.ok) continue; // e.g. no favicon.ico at this path
+      const buffer = await res.arrayBuffer();
+      results.push({
+        url: iconUrl,
+        type: 'Icon (declared, not organically fetched)',
+        bytes: buffer.byteLength,
+        transferBytes: buffer.byteLength,
+      });
+    } catch {
+      // Unreachable resource shouldn't crash the whole report.
+    }
+  }
+  return results;
+}
+
 // Uses the CDP Network domain directly (not response.headers()['content-length'],
 // which is frequently absent over HTTP/2 or chunked transfer-encoding). Network.dataReceived
 // accumulates decoded (uncompressed) body bytes per request; Network.loadingFinished reports
@@ -100,25 +175,29 @@ async function collectRequests(url) {
     await page.goto(url, { waitUntil: 'load', timeout: 30_000 });
     // Late-firing analytics/tag-manager beacons can land after load.
     await page.waitForTimeout(5_000);
+
+    const entries = [];
+    for (const [requestId, meta] of requestMeta) {
+      const bytes = decodedBytesByRequestId.get(requestId) ?? 0;
+      const finished = finishedRequestIds.has(requestId);
+      // Count partial bytes of requests still in flight (or failed) at
+      // measurement end; skip only requests that received no data at all.
+      if (!finished && bytes === 0) continue;
+      entries.push({
+        url: meta.url,
+        type: meta.type,
+        bytes,
+        transferBytes: transferBytesByRequestId.get(requestId) ?? 0,
+      });
+    }
+
+    const capturedUrls = new Set(entries.map(e => e.url));
+    entries.push(...(await collectDeclaredIconResources(page, capturedUrls)));
+
+    return entries;
   } finally {
     await browser.close();
   }
-
-  const entries = [];
-  for (const [requestId, meta] of requestMeta) {
-    const bytes = decodedBytesByRequestId.get(requestId) ?? 0;
-    const finished = finishedRequestIds.has(requestId);
-    // Count partial bytes of requests still in flight (or failed) at
-    // measurement end; skip only requests that received no data at all.
-    if (!finished && bytes === 0) continue;
-    entries.push({
-      url: meta.url,
-      type: meta.type,
-      bytes,
-      transferBytes: transferBytesByRequestId.get(requestId) ?? 0,
-    });
-  }
-  return entries;
 }
 
 function aggregateByUrl(entries) {


### PR DESCRIPTION
## Summary
The 512KB Club's FAQ designates DebugBear's Page Size Checker (`debugbear.com/test/page-size-checker`) as the tool to verify membership against, and its "Full Size" (uncompressed) column — not the default "Size" (transfer) column — is the metric matching the club's stated rule ("total UNCOMPRESSED web resources must not exceed 512KB"). Ran that exact tool live against kyle.skrinak.com: ~693.5 KB uncompressed.

Our own `check-live-weight.mjs` was under-counting relative to that: verified empirically that Playwright's Chromium (both headless and headed) doesn't organically fetch favicon/manifest-icon links the way DebugBear's real-browser test does — our script's prior runs never captured `favicon.ico`, `site.webmanifest`, or any manifest icon file at all.

**Fix:** `collectDeclaredIconResources()` explicitly fetches `favicon.ico`, the manifest file, and the smallest manifest icon that has an explicit `purpose` field (skipping a bare favicon-fallback entry with no `purpose`, and skipping `apple-touch-icon.png`/alternate favicon sizes/larger manifest icons — DebugBear's real-browser test didn't fetch those either). Result matches DebugBear's captured resource set and total almost exactly: **693.4 KiB** vs. their ~693.5 KB.

This corrects issue #299's reported figure — its current "over budget by 106.3 KiB" understates the real gap; corrected to ~181 KiB over, per this fix (comment posted on #299).

**Per Copilot review:** the manifest JSON fetch was mislabeled `Icon (declared, not organically fetched)` in the report output, alongside the actual icon files. Split into a distinct `Manifest (declared, not organically fetched)` label so the report stays interpretable — no change to byte totals.

## Test plan
- [x] Ran against production (`https://kyle.skrinak.com/`) — 693.4 KiB uncompressed, matches DebugBear's Page Size Checker almost exactly (same resource set: `favicon.ico`, `site.webmanifest`, `web-app-manifest-192x192.png`, plus the organically-fetched requests)
- [x] Ran against a second page (`/about/`) — no crash, icon resources correctly re-fetched per page
- [x] `--budget=` override still works (tested raising the budget, confirms the pass/fail logic and formatting are unaffected)
- [x] `npx eslint scripts/check-live-weight.mjs` — clean
- [x] Re-verified after the manifest/icon label fix — total unchanged (693.4 KiB), manifest entry now correctly labeled

🤖 Generated with [Claude Code](https://claude.com/claude-code)