### PR TITLE
Remove stale project-level model pin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "model": "claude-sonnet-4-5-20250929",
   "thinking": {
     "enabled": true,
     "budget": 8000
@@ -18,7 +17,7 @@
     "servers": {}
   },
   "comments": {
-    "model": "Use Sonnet 4.5 by default (cheaper than Opus)",
+    "model": "No project-level model pin — inherits the user's global/session default.",
     "thinking_budget": "Reduced from default 31999 to 8000 tokens for simple tasks",
     "auto_compact": "Trigger at 85% instead of 95% to maintain quality",
     "max_file_size": "Warn before reading files >500 lines",


### PR DESCRIPTION
Removes the Sonnet 4.5 project-level model pin in .claude/settings.json — no longer reflects current usage; project now inherits the user's global/session model default.